### PR TITLE
An alternate hack to detect Vagrant

### DIFF
--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -23,11 +23,7 @@ module Morph
 
       # TODO the local path will be different if docker isn't running through Vagrant (i.e. locally)
       # HACK to detect vagrant installation in crude way
-      if Rails.root.to_s =~ /\/var\/www/
-        local_root_path = Rails.root
-      else
-        local_root_path = "/vagrant"
-      end
+      local_root_path = Dir.exists?("/vagrant") ? "/vagrant" : Rails.root
 
       begin
         c.start("Binds" => [


### PR DESCRIPTION
That works if you don't have Morph installed to /var/www like if
you're developing under Linux.

I'm not sure if this will work properly under vagrant, hence the PR.
