### PR TITLE
Always keep the repository checkout up to date with GitHub

### DIFF
--- a/lib/morph/github.rb
+++ b/lib/morph/github.rb
@@ -11,7 +11,7 @@ module Morph
         # So falling back to shelling out to the git command
         #gritty = Grit::Repo.new(repo_path).git
         #puts gritty.pull({:raise => true}, "origin", "master")
-        system("cd #{repo_path}; git pull")
+        system("cd #{repo_path} && git fetch && git reset --hard FETCH_HEAD")
       else
         puts "Cloning git repo #{git_url}..."
         puts gritty.clone({:verbose => true, :progress => true, :raise => true}, git_url, repo_path)


### PR DESCRIPTION
Don't merge with earlier changesets -- the user might have chosen to force-push
over them. If we run git pull, it would attempt to merge the changes,
potentially resulting in a conflicted state.