### PR TITLE
Only attempt to start Discourse after it's first bootstrapped

### DIFF
--- a/provisioning/roles/discourse/handlers/main.yml
+++ b/provisioning/roles/discourse/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
 - name: restart nginx
   service: name=nginx state=restarted
+- name: start discourse
+  command: ./launcher start app chdir=/var/docker

--- a/provisioning/roles/discourse/tasks/main.yml
+++ b/provisioning/roles/discourse/tasks/main.yml
@@ -30,9 +30,7 @@
 
 - name: Bootstrap discourse app
   command: ./launcher bootstrap app chdir=/var/docker creates=/var/docker/shared/standalone/log/rails/production.log
-
-- name: Start discourse app
-  command: ./launcher start app chdir=/var/docker
+  notify: start discourse
 
 - name: Ensure that ssl/discourse directory exist
   file: path=/etc/nginx/ssl/discourse owner=deploy group=deploy state=directory


### PR DESCRIPTION
The launcher's exit code is 1 when attempting to start an already
running Discourse so the Ansible task fails.

Fixes #498