### PR TITLE
link to specific docker osx installation guide and mention kitematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ access this, run the following to give your account admin rights:
 
 If you're doing your development on Linux you're in luck because installing Docker is pretty straightforward. Just follow the instructions on the [Docker site](http://www.docker.io/gettingstarted/#h_installation).
 
-If you're on OSX you could follow the instructions on the [Docker site](http://www.docker.io/gettingstarted/#h_installation) as well. However there will be some extra configuration you will need to do to make it work with Morph.
+If you're on OSX you could follow the [instructions on the Docker site](https://docs.docker.com/installation/mac/). Docker encourage OSX users to install their [Kitematic](https://kitematic.com/) application, a [GUI](https://en.wikipedia.org/wiki/Graphical_user_interface) for running Docker, that works with Morph. However there will be some extra configuration you will need to do to make it work with Morph.
 
 We've made it easier by providing a Vagrantfile that sets up a VM, installs docker on it and makes sure that your development box can talk to docker on the VM.
 


### PR DESCRIPTION
This saves osx users a few clicks and reassures them that they can run morph with [kitematic](https://kitematic.com/).

With following sentence @mlandauer :

> However there will be some extra configuration you will need to do to make it work with Morph.

I'm not aware of these extra steps, and I've got morph running, but am yet to run any scrappers, so it could break yet. 

If that sentence isn't necessary, let's remove it.