### PR TITLE
Fresh quotes for the landing page

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -70,3 +70,11 @@ body {
   height: 500px;
   color: white;
 }
+
+.banner-quotes {
+  footer {
+    &:before {
+      content: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -73,6 +73,8 @@ body {
 
 .banner-quotes {
   footer {
+    font-size: 1em;
+
     &:before {
       content: none;
     }

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -78,5 +78,9 @@ body {
     &:before {
       content: none;
     }
+
+    img {
+      margin-right: .5em;
+    }
   }
 }

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -19,7 +19,7 @@ body {
   margin-bottom: 309px;
 }
 
-footer {
+.site-footer {
   position: absolute;
   bottom: 0;
   width: 100%;

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -73,7 +73,7 @@ body {
 
 .banner-quotes {
   footer {
-    font-size: 1em;
+    font-size: 1.125em;
 
     &:before {
       content: none;

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer
+%footer.site-footer
 	.container.text-muted
 		.row
 			.col-sm-6

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -41,21 +41,15 @@
 .container#quotes
   .container
     .row
-      .col-md-4
+      .col-md-6
         %blockquote
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %small
             = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=30", size: "50x50" , class: "img-circle"
             = link_to "J. Pablo Pérez Trabucco", "https://morph.io/rezzo"
-      .col-md-4
+      .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %small
             = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=80", size: "50x50", class: "img-circle"
             = link_to "Will", "https://morph.io/hailspuds"
-      .col-md-4
-        %blockquote
-          %p Does it come with plasticine?
-          %small
-            = image_tag "https://www.gravatar.com/avatar/87bb46366f13106c2deebf655af73b38?s=30", size: "50x50", class: "img-circle"
-            = link_to "Kat Szuminska", "https://twitter.com/katska"

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -38,7 +38,7 @@
       .col-md-8
       %p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
-.container#quotes
+.container#quotes.banner-quotes
   .container
     .row
       .col-md-6

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -46,10 +46,10 @@
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %footer
             = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle"
-            = link_to "J. Pablo Pérez Trabucco", "https://morph.io/rezzo"
+            = link_to "rezzo", "https://morph.io/rezzo"
       .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %footer
             = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle"
-            = link_to "Will", "https://morph.io/hailspuds"
+            = link_to "hailspuds", "https://morph.io/hailspuds"

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -44,12 +44,12 @@
       .col-md-6
         %blockquote
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
-          %small
+          %footer
             = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=30", size: "50x50" , class: "img-circle"
             = link_to "J. Pablo Pérez Trabucco", "https://morph.io/rezzo"
       .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
-          %small
+          %footer
             = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=80", size: "50x50", class: "img-circle"
             = link_to "Will", "https://morph.io/hailspuds"

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -45,11 +45,11 @@
         %blockquote
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %footer
-            = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=30", size: "50x50" , class: "img-circle"
+            = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle"
             = link_to "J. Pablo Pérez Trabucco", "https://morph.io/rezzo"
       .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %footer
-            = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=80", size: "50x50", class: "img-circle"
+            = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle"
             = link_to "Will", "https://morph.io/hailspuds"

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -43,16 +43,16 @@
     .row
       .col-md-4
         %blockquote
-          %p Allow me to be the first to say amazeballs!
+          %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %small
-            = image_tag "https://www.gravatar.com/avatar/1d9536edb482e9e1f56b86459abb06c4?s=30", size: "50x50" , class: "img-circle"
-            = link_to "Henare Degan", "https://twitter.com/henaredegan"
+            = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=30", size: "50x50" , class: "img-circle"
+            = link_to "J. Pablo Pérez Trabucco", "https://morph.io/rezzo"
       .col-md-4
         %blockquote
-          %p I like it but then I would say that
+          %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %small
-            = image_tag "https://www.gravatar.com/avatar/30e5eec125c81e549294137a3ddd6c74?s=30", size: "50x50", class: "img-circle"
-            = link_to "Matthew Landauer", "https://twitter.com/matthewlandauer"
+            = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=80", size: "50x50", class: "img-circle"
+            = link_to "Will", "https://morph.io/hailspuds"
       .col-md-4
         %blockquote
           %p Does it come with plasticine?


### PR DESCRIPTION
This replaces the current three quotes by the OpenAustralia Foundation directors with two quotes by people who use Morph.

This is also a first pass at making the layout of the quotes slightly more polished and emphasise the humans.

Maybe we should use their real full names rather than user names? I'm torn on that.

Also, on later iterations, it might be nice to adjust the spacing around the quotes overall, but I thought I'd leave it for this first pass as other elements will change anyway.

## Before:

![screen shot 2015-04-09 at 6 04 36 pm](https://cloud.githubusercontent.com/assets/1239550/7062761/cd20b252-dee3-11e4-8d87-5fdb5d7c62bf.png)

## After:

![screen shot 2015-04-09 at 6 04 16 pm](https://cloud.githubusercontent.com/assets/1239550/7062766/d1dab536-dee3-11e4-8b49-52c2f9589e06.png)


Closes #417