### PR TITLE
Change logo back to Helvetica Neue

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -47,7 +47,11 @@ footer {
 }
 
 .navbar-brand {
-  font-family: 'Comfortaa', cursive;
+  letter-spacing: 1px;
+
+  .navbar-default & {
+    color: #555;
+  }
 }
 
 .container#banner {


### PR DESCRIPTION
This changes the logo back to Helvetica Neue to make it more consistent with the site for the first pass of the new homepage.

## Before

![screen shot 2015-04-10 at 10 00 12 am](https://cloud.githubusercontent.com/assets/1239550/7079521/99ef6dbc-df68-11e4-8e12-4991b42f4555.png)

## After

![screen shot 2015-04-10 at 10 10 46 am](https://cloud.githubusercontent.com/assets/1239550/7079844/d0980cc6-df6c-11e4-9d1e-d336e63a5d1b.png)

closes #553 