### PR TITLE
Remove big logo from Introduction section

### DIFF
--- a/app/assets/stylesheets/static.css.scss
+++ b/app/assets/stylesheets/static.css.scss
@@ -24,10 +24,9 @@
   }
 }
 
-.container#introducing {
-  width: 100%;
+.jumbotron#introducing {
   background-color: #b1d05f;
-  padding-top: 100px;
+  text-align: center;
 }
 
 .container#quotes {

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -30,13 +30,9 @@
 
 
 
-.container#introducing
+.jumbotron#introducing
   .container
-    .row
-      .col-md-4
-        = image_tag "logo.png", size: "300x300", class: "img-responsive"
-      .col-md-8
-      %p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    %p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 .container#quotes.banner-quotes
   .container

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -34,6 +34,8 @@
   .container
     %p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
+    = link_to "Add your scraper", user_omniauth_authorize_path(:github), class: "btn btn-default btn-lg"
+
 .container#quotes.banner-quotes
   .container
     .row


### PR DESCRIPTION
This removes the big logo from the introduction section as discussed in #556 .

Also adds a call to action link, "add your scraper", after the paragraph.

closes #556 

![screen shot 2015-04-10 at 1 18 42 pm](https://cloud.githubusercontent.com/assets/1239550/7081400/9b3688a6-df84-11e4-95e2-bf0c7f12f862.png)
![screen shot 2015-04-10 at 1 18 50 pm](https://cloud.githubusercontent.com/assets/1239550/7081401/9b3955cc-df84-11e4-8385-0f7bae48e5fc.png)
