### PR TITLE
Add full names & details to landing page quotes and adjust design to suit

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -76,6 +76,10 @@ body {
 }
 
 .banner-quotes {
+  p {
+    font-size: 1.125em;
+  }
+
   footer {
     font-size: 1.125em;
 

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -81,7 +81,7 @@ body {
   }
 
   footer {
-    font-size: 1.125em;
+    font-size: 1em;
 
     &:before {
       content: none;
@@ -95,6 +95,10 @@ body {
       span {
         display: block;
       }
+    }
+
+    .p-name {
+      font-size: 1.125em;
     }
   }
 }

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -81,6 +81,7 @@ body {
   }
 
   footer {
+    margin-top: 1em;
     font-size: 1em;
 
     &:before {

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -86,5 +86,11 @@ body {
     img {
       margin-right: .5em;
     }
+
+    .h-card {
+      span {
+        display: block;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/static.css.scss
+++ b/app/assets/stylesheets/static.css.scss
@@ -31,5 +31,6 @@
 
 .container#quotes {
   width: 100%;
-  padding-top: 100px;
+  padding-top: 48px;
+  padding-bottom: 48px;
 }

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -45,7 +45,7 @@
           %footer
             = link_to "https://morph.io/rezzo", class: 'h-card media' do
               .pull-left
-                = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle media-object"
+                = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=70", class: "img-circle media-object"
               .media-body
                 %span.p-name J. Pablo Pérez Trabucco
                 %span.p-org Fundación Ciudadano Inteligente
@@ -57,7 +57,7 @@
           %footer
             = link_to "https://morph.io/hailspuds", class: 'h-card media' do
               .pull-left
-                = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle media-object"
+                = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=70", class: "img-circle media-object"
               .media-body
                 %span.p-name Will Ockenden
                 %span.p-org Australian Broadcasting Corporation

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -43,14 +43,18 @@
         %blockquote
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %footer
-            = link_to "https://morph.io/rezzo" do
+            = link_to "https://morph.io/rezzo", class: 'h-card' do
               = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle"
-              %span.quote-source rezzo
+              %span.p-name J. Pablo Pérez Trabucco
+              %span.p-org Fundación Ciudadano Inteligente
+              %span.p-country-name Chile
 
       .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %footer
-            = link_to "https://morph.io/hailspuds" do
+            = link_to "https://morph.io/hailspuds", class: 'h-card' do
               = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle"
-              %span.quote-source hailspuds
+              %span.p-name Will Ockenden
+              %span.p-org Australian Broadcasting Corporation
+              %span.p-country-name Australia

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -43,18 +43,22 @@
         %blockquote
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %footer
-            = link_to "https://morph.io/rezzo", class: 'h-card' do
-              = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle"
-              %span.p-name J. Pablo Pérez Trabucco
-              %span.p-org Fundación Ciudadano Inteligente
-              %span.p-country-name Chile
+            = link_to "https://morph.io/rezzo", class: 'h-card media' do
+              .pull-left
+                = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle media-object"
+              .media-body
+                %span.p-name J. Pablo Pérez Trabucco
+                %span.p-org Fundación Ciudadano Inteligente
+                %span.p-country-name Chile
 
       .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %footer
-            = link_to "https://morph.io/hailspuds", class: 'h-card' do
-              = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle"
-              %span.p-name Will Ockenden
-              %span.p-org Australian Broadcasting Corporation
-              %span.p-country-name Australia
+            = link_to "https://morph.io/hailspuds", class: 'h-card media' do
+              .pull-left
+                = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle media-object"
+              .media-body
+                %span.p-name Will Ockenden
+                %span.p-org Australian Broadcasting Corporation
+                %span.p-country-name Australia

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -43,11 +43,14 @@
         %blockquote
           %p Scrapers are kept in public github repos and then we consume the data from an API, delicious! Is like scrapers with steroids!
           %footer
-            = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle"
-            = link_to "rezzo", "https://morph.io/rezzo"
+            = link_to "https://morph.io/rezzo" do
+              = image_tag "https://www.gravatar.com/avatar/976cd09092e36aad6a7b959822b78c89?s=60", size: "60x60" , class: "img-circle"
+              %span.quote-source rezzo
+
       .col-md-6
         %blockquote
           %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %footer
-            = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle"
-            = link_to "hailspuds", "https://morph.io/hailspuds"
+            = link_to "https://morph.io/hailspuds" do
+              = image_tag "https://avatars3.githubusercontent.com/u/851118?v=3&s=60", size: "60x60", class: "img-circle"
+              %span.quote-source hailspuds


### PR DESCRIPTION
This shows the full name, organisation and origin of the quote authors instead of their morph user name.

This is to emphasise them as people and put their use of morph into their civic tech / journalism contexts/

I've also increase the font size of the quotes so they don't lose emphasis next to this bigger block of text, and adjusted the balance of the layout to suit. This could do with more refinement for small screens, which will be a lot quicker once we're using the new bootstrap implementation ( #560 ).

closes #555 

![screen shot 2015-04-12 at 12 30 21 pm](https://cloud.githubusercontent.com/assets/1239550/7104168/8713975a-e110-11e4-86e7-345ad6a52b12.png)