### PR TITLE
Fix navbar wrapping on mid sized screens

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,0 +1,1 @@
+$grid-float-breakpoint: 60em;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -4,6 +4,7 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "font-awesome";
+@import "global/site-header";
 @import "bootstrap_and_overrides";
 @import "documentation";
 @import "scrapers";

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,3 +1,4 @@
+@import "variables";
 @import "api";
 // "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
 @import "bootstrap-sprockets";

--- a/app/assets/stylesheets/global/_site-header.scss
+++ b/app/assets/stylesheets/global/_site-header.scss
@@ -1,0 +1,7 @@
+.site-header {
+  .container {
+    @media (min-width: $grid-float-breakpoint) and (max-width: $screen-md-max) {
+      width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/global/_site-header.scss
+++ b/app/assets/stylesheets/global/_site-header.scss
@@ -4,4 +4,11 @@
       width: 100%;
     }
   }
+
+  form[role="search"] {
+    // restrict width of search form to avoid nav-bar wrapping
+    @media (min-width: $grid-float-breakpoint) and (max-width: 67em) {
+      width: 13em;
+    }
+  }
 }

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,4 +1,4 @@
-%nav.navbar.navbar-default.navbar-fixed-top(role="navigation")
+%nav.site-header.navbar.navbar-default.navbar-fixed-top(role="navigation")
   .container
     .navbar-header
       %button.navbar-toggle(type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1")


### PR DESCRIPTION
For mid sized screens this:

* makes the header navbar full width
* reduces the width of the header search form

to stops the nav bar wrapping at these widths.

It also makes the header change layout at a slighting wider media query.

![screen shot 2015-04-13 at 2 57 00 pm](https://cloud.githubusercontent.com/assets/1239550/7110022/608415fa-e1ed-11e4-8763-54da5cb18404.png)


fixes https://github.com/openaustralia/morph/issues/531