### PR TITLE
don't display the mini-profiler on load

### DIFF
--- a/config/initializers/mini_profiler.rb
+++ b/config/initializers/mini_profiler.rb
@@ -1,0 +1,3 @@
+# Config for mini profiler
+# https://github.com/MiniProfiler/rack-mini-profiler#configuration-options
+Rack::MiniProfiler.config.start_hidden = true if Rails.env.development?


### PR DESCRIPTION
This adds an initialiser to configure mini profiler to be hidden on page load. You can show the profiler with Alt/Option+P.

This only configures mini profiler in development, as the Gem is only available in development.

See https://github.com/MiniProfiler/rack-mini-profiler#configuration-options