### PR TITLE
add first pass of explanation for no search results

### DIFF
--- a/app/views/static/search.html.haml
+++ b/app/views/static/search.html.haml
@@ -6,3 +6,17 @@
   = paginate @scrapers
   = render partial: "sync/scrapers/scraper", collection: @scrapers
   = paginate @scrapers
+
+  - if @scrapers.empty?
+    %h2 No results found
+    %p
+      Sorry, we couldn't find any scrapers relevant to your search term
+      %strong “#{@q}”.
+    %p
+      Suggestions:
+
+    %ul
+      %li check the spelling
+      %li try some more general or alternate terms
+
+    %p You could also try browsing all #{link_to "scrapers", scrapers_path} or #{link_to "users", users_path}.


### PR DESCRIPTION
![screen shot 2015-04-15 at 11 16 11 am](https://cloud.githubusercontent.com/assets/1239550/7150630/eb4d3e68-e360-11e4-89f3-65bb9010581a.png)

closes #526

this is adapted from They Vote For You
https://theyvoteforyou.org.au/search?utf8=%E2%9C%93&query=alshdbfasdkbga;sdg