### PR TITLE
Change 'browse' navigation label to 'explore'

### DIFF
--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -17,7 +17,7 @@
             %li(class="divider")
             %li= link_to "Add scraper from GitHub", github_new_scraper_path
             %li= link_to "Fork scraper from ScraperWiki", scraperwiki_new_scraper_path
-        %li= link_to "Browse", scrapers_path
+        %li= link_to "Explore", scrapers_path
         %li= link_to "Pricing", pricing_path
         %li= link_to "Documentation", documentation_index_path
         - if user_signed_in? && current_user.admin?


### PR DESCRIPTION
"Explore" is a friendlier, more active term.

Also, reflects the term used by Github, which citizens will be familiar with.

fixes #487