### PR TITLE
Use the original Bootstap menu toggler icon

### DIFF
--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,13 +1,13 @@
 %nav.site-header.navbar.navbar-default.navbar-fixed-top(role="navigation")
   .container
     .navbar-header
-      %button.navbar-toggle(type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1")
+      %button.navbar-toggle(type="button" data-toggle="collapse" data-target=".site-header .navbar-collapse")
         %span.sr-only Toggle navigation
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
       = link_to "morph.io", root_path, class: "navbar-brand"
-    .collapse.navbar-collapse#bs-example-navbar-collapse-1
+    .collapse.navbar-collapse
       %ul.nav.navbar-nav
         -# TODO set class to "active" when this is the current page
         %li.dropdown{class: ("disabled" unless can? :new, Scraper)}

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -3,7 +3,9 @@
     .navbar-header
       %button.navbar-toggle(type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1")
         %span.sr-only Toggle navigation
-        %span.fa.fa-bars
+        %span.icon-bar
+        %span.icon-bar
+        %span.icon-bar
       = link_to "morph.io", root_path, class: "navbar-brand"
     .collapse.navbar-collapse#bs-example-navbar-collapse-1
       %ul.nav.navbar-nav


### PR DESCRIPTION
Changes markup to use the bootstrap menu toggler pattern from http://getbootstrap.com/components/#navbar-default

instead of the current Foundation icon which appears squashed ( see #549 )

closes #549