### PR TITLE
Move the header search to last place in the small screen menu

### DIFF
--- a/app/assets/stylesheets/global/_site-header.scss
+++ b/app/assets/stylesheets/global/_site-header.scss
@@ -12,3 +12,9 @@
     }
   }
 }
+
+// override bootstrap default height, which
+// is too short for our content.
+.navbar-fixed-top .navbar-collapse {
+  max-height: 370px;
+}

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -34,15 +34,6 @@
 
       %ul.nav.navbar-nav.navbar-right
         %li
-          = form_tag search_path, method: "get", role: "search", class: "navbar-form" do
-            .input-group
-              = label_tag :query, "Search", class: 'sr-only'
-              = search_field_tag :q, @q, maxlength: "256", name: "q", type: "search", placeholder: "Search", class: "form-control"
-              .input-group-btn
-                = button_tag value: 'Submit', class: 'btn btn-default', name: nil do
-                  %span.sr-only Submit
-                  %i.fa.fa-search
-        %li
           - if user_signed_in?
             = link_to current_user do
               = owner_image(current_user, 20, false)
@@ -52,3 +43,12 @@
         %li
           - if user_signed_in?
             = link_to "Sign out", destroy_user_session_path
+
+      = form_tag search_path, method: "get", role: "search", class: "navbar-form navbar-right" do
+        .input-group
+          = label_tag :query, "Search", class: 'sr-only'
+          = search_field_tag :q, @q, maxlength: "256", name: "q", type: "search", placeholder: "Search", class: "form-control"
+          .input-group-btn
+            = button_tag value: 'Submit', class: 'btn btn-default', name: nil do
+              %span.sr-only Submit
+              %i.fa.fa-search


### PR DESCRIPTION
This moves the header search to last place in the menu source order. This makes it the final item in the small screen menu, but maintain it's current position as third from the right on wide screens.

This puts the citizens profile as a higher place in the small screen menu and means that all the links are group together.

![screen shot 2015-04-15 at 2 54 39 pm](https://cloud.githubusercontent.com/assets/1239550/7152482/17f8a69a-e380-11e4-952f-03f64a6446c7.png)

also fixes #550 