### PR TITLE
move database size to the download link

### DIFF
--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -19,9 +19,9 @@
                 = button_link_to "sign in with GitHub", user_omniauth_authorize_path(:github)
               .btn-group
                 = button_link_to "Download table (as CSV)", data_scraper_path(scraper, format: :csv, query: scraper.database.select_all(table), key: (current_user.api_key if current_user)), disabled: !signed_in?
-                = button_link_to "Download SQLite database", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
+                = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
-            %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)} (#{number_to_human_size scraper.database.sqlite_db_size})
+            %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data
               %table.table.table-striped.table-bordered.table-condensed
                 - unless rows.empty?


### PR DESCRIPTION
In it's current location next to the table row count, it's ambiguous whether it refers to
table size or database size.

closes #591

## Before

![screen shot 2015-04-15 at 3 13 36 pm](https://cloud.githubusercontent.com/assets/1239550/7153962/67973e1e-e394-11e4-8467-e6f93e012b67.png)


## After

![screen shot 2015-04-15 at 5 07 15 pm](https://cloud.githubusercontent.com/assets/1239550/7153960/5fa4354a-e394-11e4-85c9-49ecf43799ba.png)
