### PR TITLE
[FOR REVIEW] show add new scraper button on orgs if current user is a member

### DIFF
--- a/app/views/owners/show.html.haml
+++ b/app/views/owners/show.html.haml
@@ -52,7 +52,7 @@
     .list-group= sync partial: "scraper", collection: @erroring_scrapers
     .list-group= sync partial: "scraper", collection: @other_scrapers.sort{|a,b| b.updated_at <=> a.updated_at}
 
-  - if @owner == current_user
+  - if @owner == current_user || @owner.organization? && @owner.users.include?(current_user)
     .btn-group
       = button_link_to "#", class: "dropdown-toggle", data: {toggle: "dropdown"} do
         Add Scraper


### PR DESCRIPTION
This simply adds the 'add new scraper' button to orgs, in the same location as on your user page.

I don't have any organisations in my dev setup that I'm not a member of, and I couldn’t work out how to add one. So I couldn't actually test that this doesn't show if you're logged in and non a member of the org. But it does show if you are a member, and it doesn't show if you're not logged it.

@mlandauer could you please test this or let me know how to add new test orgs?

closes #480 
