### PR TITLE
Incorporate the flash/alert into the head on Owners#show and homepage

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -5,6 +5,7 @@
 @import "bootstrap";
 @import "font-awesome";
 @import "global/site-header";
+@import "global/alerts";
 @import "bootstrap_and_overrides";
 @import "documentation";
 @import "scrapers";

--- a/app/assets/stylesheets/global/_alerts.scss
+++ b/app/assets/stylesheets/global/_alerts.scss
@@ -1,0 +1,5 @@
+.alert-wrapper {
+  body.owners.show & {
+    background-color: $offset-color;
+  }
+}

--- a/app/assets/stylesheets/global/_alerts.scss
+++ b/app/assets/stylesheets/global/_alerts.scss
@@ -2,4 +2,12 @@
   body.owners.show & {
     background-color: $offset-color;
   }
+
+  body.static.index & {
+    position: absolute;
+    top: 3.4em;
+    background: transparent;
+    z-index: 99;
+    width: 100%;
+  }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,8 @@ module ApplicationHelper
   def bs_nav_link(text, url)
     content_tag(:li, link_to(text, url), class: ("active" if current_page?(url)))
   end
+
+  def body_class
+    controller.controller_path + " " + controller.action_name
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,13 +25,14 @@
     = render "google_analytics"
     = render "shared/nav"
 
-    .container
-      - if signed_in? && SiteSetting.read_only_mode
-        .alert.alert-warning.read-only-mode
-          %i.fa.fa-bell-o.fa-lg.pull-left
-          The site is currently <strong>read-only</strong> because we're doing some essential maintenance.
-          Scrapers can not be created or run. The good news is you can continue to browse the site.
-      = bootstrap_flash
+    .alert-wrapper
+      .container
+        - if signed_in? && SiteSetting.read_only_mode
+          .alert.alert-warning.read-only-mode
+            %i.fa.fa-bell-o.fa-lg.pull-left
+            The site is currently <strong>read-only</strong> because we're doing some essential maintenance.
+            Scrapers can not be created or run. The good news is you can continue to browse the site.
+        = bootstrap_flash
     = content_for?(:content) ? yield(:content) : yield
     = render "heap_analytics_identify"
     = render "shared/footer"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,7 @@
     = javascript_include_tag Sync.adapter_javascript_url
     = render "heap_analytics"
 
-  %body
+  %body{class: "#{body_class}"}
     = render "google_analytics"
     = render "shared/nav"
 


### PR DESCRIPTION
This adds a wrapping element around the alert, which is then styled specially on the Owners#show page and the home page.

This is because currently it looks odd/broken, jutting into the header on these pages. See #548 .

I've added a class to the body element to indicate the controller and action, as we have on They Vote For You, which allows us to make these style changes.

fixes #548

![screen shot 2015-04-17 at 5 36 01 pm](https://cloud.githubusercontent.com/assets/1239550/7197803/b19a14b0-e528-11e4-9023-a2fc5a5bd0f1.png)
![screen shot 2015-04-17 at 5 36 09 pm](https://cloud.githubusercontent.com/assets/1239550/7197805/b19fecf0-e528-11e4-82ad-78028b977242.png)
![screen shot 2015-04-17 at 5 37 06 pm](https://cloud.githubusercontent.com/assets/1239550/7197804/b19e4da0-e528-11e4-9aca-a375558a5460.png)
![screen shot 2015-04-17 at 5 37 11 pm](https://cloud.githubusercontent.com/assets/1239550/7197806/b1a05cc6-e528-11e4-9471-1c3edb1f2f58.png)