### PR TITLE
Full width alerts and messages beneath the site header.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -7,6 +7,7 @@
 @import "vendor/tablesaw.stackonly";
 
 @import "global/site-header";
+@import "global/alerts";
 @import "bootstrap_and_overrides";
 @import "documentation";
 @import "scrapers";

--- a/app/assets/stylesheets/global/_alerts.scss
+++ b/app/assets/stylesheets/global/_alerts.scss
@@ -1,0 +1,5 @@
+.site-header + .alert,
+body > .alert + .alert {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -16,9 +16,19 @@ module BootstrapFlashHelper
       next unless ALERT_TYPES.include?(type)
 
       Array(message).each do |msg|
-        text = content_tag(:div,
-                           content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
-                           msg.html_safe, :class => "alert fade in alert-#{type} #{options[:class]}")
+        text = content_tag(
+                  :div,
+                  content_tag(
+                    :div,
+                    content_tag(
+                      :button,
+                      raw("&times;"),
+                      :class => "close", "data-dismiss" => "alert"
+                    ) + msg.html_safe,
+                    :class => "container"
+                  ),
+                  :class => "alert fade in alert-#{type} #{options[:class]}"
+                )
         flash_messages << text if msg
       end
     end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,13 +25,13 @@
     = render "google_analytics"
     = render "shared/nav"
 
-    .container
-      - if signed_in? && SiteSetting.read_only_mode
-        .alert.alert-warning.read-only-mode
+    - if signed_in? && SiteSetting.read_only_mode
+      .alert.alert-warning.read-only-mode
+        .container
           %i.fa.fa-bell-o.fa-lg.pull-left
           The site is currently <strong>read-only</strong> because we're doing some essential maintenance.
           Scrapers can not be created or run. The good news is you can continue to browse the site.
-      = bootstrap_flash
+    = bootstrap_flash
     = content_for?(:content) ? yield(:content) : yield
     = render "heap_analytics_identify"
     = render "shared/footer"


### PR DESCRIPTION
This makes the flash messages full width so that they suit to pages with full width colour or image background headers better. This is achieved by moving the `div.container` that wraps alerts inside the `div.alert`.

closes #548 

![screen shot 2015-04-20 at 12 56 26 pm](https://cloud.githubusercontent.com/assets/1239550/7222984/afc0a880-e75c-11e4-9851-616ec11a0b02.png)
![screen shot 2015-04-20 at 12 39 24 pm](https://cloud.githubusercontent.com/assets/1239550/7222968/53209982-e75c-11e4-98ca-ae5b8de220ef.png)
![screen shot 2015-04-20 at 12 39 29 pm](https://cloud.githubusercontent.com/assets/1239550/7222969/5324f75c-e75c-11e4-9cf1-7c1913e2e596.png)
![screen shot 2015-04-20 at 12 39 42 pm](https://cloud.githubusercontent.com/assets/1239550/7222970/5327d4b8-e75c-11e4-8d1a-6aca48209c3e.png)
![screen shot 2015-04-20 at 12 39 52 pm](https://cloud.githubusercontent.com/assets/1239550/7222971/532a7d9e-e75c-11e4-81ab-14c7fae27257.png)
