### PR TITLE
Change the title of the site from "Morph" to "morph.io"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Stories in Ready](https://badge.waffle.io/openaustralia/morph.png?label=ready)](https://waffle.io/openaustralia/morph) [![Build Status](https://travis-ci.org/openaustralia/morph.png?branch=master)](https://travis-ci.org/openaustralia/morph) [![Code Climate](https://codeclimate.com/github/openaustralia/morph.png)](https://codeclimate.com/github/openaustralia/morph)
 
-## Morph: A scraping platform
+## morph.io: A scraping platform
 
 * A [Heroku](https://www.heroku.com/) for [Scrapers](https://en.wikipedia.org/wiki/Web_scraping)
 * All code and collaboration through [GitHub](https://github.com/)
@@ -23,7 +23,7 @@ On Linux your user account should be able to manipulate Docker (just add your us
 User-facing:
 
 * [openaustralia/morph](https://github.com/openaustralia/morph) - Main application
-* [openaustralia/morph-cli](https://github.com/openaustralia/morph-cli) - Command-line morph tool
+* [openaustralia/morph-cli](https://github.com/openaustralia/morph-cli) - Command-line morph.io tool
 * [openaustralia/scraperwiki-python](https://github.com/openaustralia/scraperwiki-python) - Fork of [scraperwiki/scraperwiki-python](https://github.com/scraperwiki/scraperwiki-python) updated to use morph.io naming conventions
 * [openaustralia/scraperwiki-ruby](https://github.com/openaustralia/scraperwiki-ruby) - Fork of [scraperwiki/scraperwiki-ruby](https://github.com/scraperwiki/scraperwiki-ruby) updated to use morph.io naming conventions
 
@@ -48,7 +48,7 @@ Running this on OSX? Read the [OSX instructions](#installing-docker-on-osx) belo
 
 Edit `config/database.yml` with your database settings
 
-Create an [application on GitHub](https://github.com/settings/applications/new) so that Morph can talk to GitHub. Fill in the following values
+Create an [application on GitHub](https://github.com/settings/applications/new) so that morph.io can talk to GitHub. Fill in the following values
 
 * Application name: __Morph (dev)__
 * Homepage URL: __http://127.0.0.1:3000__
@@ -79,7 +79,7 @@ access this, run the following to give your account admin rights:
 
 If you're doing your development on Linux you're in luck because installing Docker is pretty straightforward. Just follow the instructions on the [Docker site](http://www.docker.io/gettingstarted/#h_installation).
 
-If you're on OSX you could follow the [instructions on the Docker site](https://docs.docker.com/installation/mac/). Docker encourage OSX users to install their [Kitematic](https://kitematic.com/) application, a [GUI](https://en.wikipedia.org/wiki/Graphical_user_interface) for running Docker, that works with Morph. However there will be some extra configuration you will need to do to make it work with Morph.
+If you're on OSX you could follow the [instructions on the Docker site](https://docs.docker.com/installation/mac/). Docker encourage OSX users to install their [Kitematic](https://kitematic.com/) application, a [GUI](https://en.wikipedia.org/wiki/Graphical_user_interface) for running Docker, that works with morph.io. However there will be some extra configuration you will need to do to make it work with morph.io.
 
 We've made it easier by providing a Vagrantfile that sets up a VM, installs docker on it and makes sure that your development box can talk to docker on the VM.
 
@@ -137,7 +137,7 @@ Now visit https://dev.morph.io/
 
 #### Production provisioning and deployment
 
-To deploy Morph to production, normally you'll just want to deploy using Capistrano:
+To deploy morph.io to production, normally you'll just want to deploy using Capistrano:
 
     cap production deploy
 

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -1,7 +1,7 @@
 class AlertMailer < ActionMailer::Base
   include ActionView::Helpers::TextHelper
   include ActionView::Helpers::AssetUrlHelper
-  default from: "Morph <contact@morph.io>"
+  default from: "morph.io <contact@morph.io>"
 
   def alert_email(user, broken_runs, successful_count)
     count = broken_runs.count
@@ -19,7 +19,7 @@ class AlertMailer < ActionMailer::Base
         a.scraper.latest_successful_run_time <=> b.scraper.latest_successful_run_time
       end
     end
-    @subject = "Morph: #{pluralize(count, 'scraper')} you are watching #{count == 1 ? "is" : "are"} erroring"
+    @subject = "morph.io: #{pluralize(count, 'scraper')} you are watching #{count == 1 ? "is" : "are"} erroring"
 
     attachments.inline['logo_75x75.png'] = File.read(File.join(Rails.root, "app", "assets", path_to_image("logo_75x75.png")))
     mail(to: "#{user.name} <#{user.email}>", subject: @subject) if user.email

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -25,7 +25,7 @@ class Scraper < ActiveRecord::Base
 
   validates :name, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only have letters, numbers, '_' and '-'" }
   validates :owner, presence: true
-  validates :name, uniqueness: { scope: :owner, message: 'is already taken on Morph' }
+  validates :name, uniqueness: { scope: :owner, message: 'is already taken on morph.io' }
   validate :not_used_on_github, on: :create, unless: :github_id
   with_options if: :scraperwiki_shortname, if: :scraperwiki_url, on: :create do |s|
     s.validate :exists_on_scraperwiki
@@ -42,7 +42,7 @@ class Scraper < ActiveRecord::Base
     (watchers + owner.watchers).uniq
   end
 
-  # Given a scraper name on github populates the fields for a morph scraper but doesn't save it
+  # Given a scraper name on github populates the fields for a morph.io scraper but doesn't save it
   def self.new_from_github(full_name, octokit_client)
     repo = octokit_client.repository(full_name)
     repo_owner = Owner.find_by_nickname(repo.owner.login)
@@ -366,7 +366,7 @@ class Scraper < ActiveRecord::Base
     # Add another commit (but only if necessary) to translate the code so it runs here
     unless scraperwiki.translated_code == scraperwiki.code
       add_commit_to_master_on_github(forked_by, {scraperwiki.language.scraper_filename => scraperwiki.translated_code},
-        "Automatic update to make ScraperWiki scraper work on Morph")
+        "Automatic update to make ScraperWiki scraper work on morph.io")
     end
 
     create_scraper_progress.update("Synching repository", 80)

--- a/app/views/alert_mailer/alert_email.html.haml
+++ b/app/views/alert_mailer/alert_email.html.haml
@@ -204,7 +204,7 @@
                   %h2
                     -# Hacky way to get full url in there
                     = image_tag attachments['logo_75x75.png'].url, size: "75x75"
-                    = link_to "Morph", root_url(@analytics_params)
+                    = link_to "morph.io", root_url(@analytics_params)
                     is letting you know that
                   - @broken_runs.each do |run|
                     %h3
@@ -235,5 +235,5 @@
                   %p
                     Annoyed by these emails? Then
                     = link_to "change what you're watching", watching_user_url(@user, @analytics_params)
-                  %p= link_to "Morph.io", root_url(@analytics_params)
+                  %p= link_to "morph.io", root_url(@analytics_params)
         %td

--- a/app/views/alert_mailer/alert_email.text.erb
+++ b/app/views/alert_mailer/alert_email.text.erb
@@ -1,4 +1,4 @@
-Morph is letting you know that
+morph.io is letting you know that
 
 
 <% @broken_runs.each do |run| %>
@@ -21,4 +21,4 @@ Fix it: <%= scraper_url(run.scraper, @analytics_params) %>
 
 -----
 Annoyed by these emails? Then change what you're watching - <%= watching_user_url(@user, @analytics_params) %>
-Morph.io - <%= root_url(@analytics_params) %>
+morph.io - <%= root_url(@analytics_params) %>

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,6 +1,6 @@
 .container
   .sign_in
     %p
-      Everything on Morph is hooked into GitHub. If you don't have a GitHub account you will need to register one.
+      Everything on morph.io is hooked into GitHub. If you don't have a GitHub account you will need to register one.
     %p
       = link_to "Sign in with GitHub", user_omniauth_authorize_path(:github), class: "btn btn-primary btn-lg"

--- a/app/views/documentation/_buildpacks.md
+++ b/app/views/documentation/_buildpacks.md
@@ -1,8 +1,8 @@
 Buildpacks are a new feature that allows you to pick and choose which libraries you would like
-your scraper to use. You are no longer limited to the libraries that are preinstalled on Morph.
+your scraper to use. You are no longer limited to the libraries that are preinstalled on morph.io.
 
 The Buildpacks are borrowed from the Buildpacks used by Heroku. In principle anything that can
-run on Heroku with Buildpacks should run on Morph too. This gives you enormous flexibility with
+run on Heroku with Buildpacks should run on morph.io too. This gives you enormous flexibility with
 only small changes required to your scraper.
 
 The basic idea, which is the same for every language, is that you add a new file (or two) to your

--- a/app/views/documentation/_buildpacks_ruby.md
+++ b/app/views/documentation/_buildpacks_ruby.md
@@ -29,4 +29,4 @@ When there is no `Gemfile` and `Gemfile.lock` in the scraper repository, a defau
 ### References
 * [Heroku Ruby Support](https://devcenter.heroku.com/articles/ruby-support)
 * [Bundler](http://bundler.io/)
-* [Morph Default Gemfile](https://github.com/openaustralia/morph/blob/master/default_files/ruby/Gemfile)
+* [morph.io Default Gemfile](https://github.com/openaustralia/morph/blob/master/default_files/ruby/Gemfile)

--- a/app/views/documentation/_what_is_new.md.erb
+++ b/app/views/documentation/_what_is_new.md.erb
@@ -36,7 +36,7 @@ You can now write scrapers in Perl thanks to the effort of [@lkundrak](/lkundrak
 * Added this "What's new" page
 
 ### April 17
-* Morph now only needs to ask you for public repository read/write permissions for GitHub.
+* morph.io now only needs to ask you for public repository read/write permissions for GitHub.
   This is what we previously said:
 
   > Why do you ask for read/write access to all my GitHub repositories, even the private ones?
@@ -52,7 +52,7 @@ You can now write scrapers in Perl thanks to the effort of [@lkundrak](/lkundrak
   [changing your API](https://developer.github.com/changes/2014-04-04-create-public-repo-without-repo-scope/).
 
 * You might have heard about the [heartbleed bug](http://heartbleed.com/). On the day heartbleed was
-  announced we patched the morph server. This stops anyone from exploiting the bug to gain
+  announced we patched the morph.io server. This stops anyone from exploiting the bug to gain
   access to the SSL private key. No passwords are stored on our server because we authenticate
   against GitHub using oauth. To be safe we've refreshed everyone's github oauth access token.
 

--- a/app/views/documentation/faq/_libraries.md
+++ b/app/views/documentation/faq/_libraries.md
@@ -1,6 +1,6 @@
 The language versions and libraries available are intended as close as possible to those available on
 [ScraperWiki Classic](https://classic.scraperwiki.com/) as of January 2014. The main difference is that the scraperwiki library
-has been patched to write out by default to the convention used in Morph for the table and sqlite database names.
+has been patched to write out by default to the convention used in morph.io for the table and sqlite database names.
 
 #### Ruby 1.9.2-p320
 Here is the [list of installed Gems](https://github.com/openaustralia/morph-docker-ruby/blob/master/Gemfile) directly from the

--- a/app/views/documentation/faq/_run_locally.md
+++ b/app/views/documentation/faq/_run_locally.md
@@ -12,5 +12,5 @@ To run a scraper go to the directory you have your scraper code in and
 
     morph
 
-It will run your local scraper on the Morph server and stream the console output back to you. You can use this with any support scraper
+It will run your local scraper on the morph.io server and stream the console output back to you. You can use this with any support scraper
 language without the hassle of having to install lots of things.

--- a/app/views/documentation/pricing.html.haml
+++ b/app/views/documentation/pricing.html.haml
@@ -2,7 +2,7 @@
 .container
   %h1 Pricing
 
-  %h3 During Morph.io’s beta period the service is free
+  %h3 During morph.io’s beta period the service is free
   = image_tag "blurred_pricing.jpg", class: "center-block"
 
   :markdown
@@ -10,12 +10,12 @@
     most useful to you and also allows us to understand what it costs us to run
     this service for you.
 
-    It is our intention to keep Morph.io free for most people; so if you’re a
+    It is our intention to keep morph.io free for most people; so if you’re a
     casual user who has a few scrapers that are lightweight, morph.io will stay
     free and become an incredibly useful tool that you can depend on.
 
     For the heavy users, based on actual usage, we will be bringing in very
-    reasonable paid plans that help pay for continued development of Morph and
+    reasonable paid plans that help pay for continued development of morph.io and
     its server infrastructure.
 
     We also plan to support private scrapers which will be under a paid plan as well.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1")
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %meta(content='Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.' name='Description')
-    %title= content_for?(:title) ? "Morph: #{yield(:title)}" : "Morph"
+    %title= content_for?(:title) ? "morph.io: #{yield(:title)}" : "morph.io"
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements
     /[if lt IE 9]

--- a/app/views/owners/settings.html.haml
+++ b/app/views/owners/settings.html.haml
@@ -12,7 +12,7 @@
         You
       - else
         They
-      will need this to use the API and the Morph command line client
+      will need this to use the API and the morph.io command line client
     %p
       This key is just for #{@owner == current_user ? "you" : "them"}. Don't give it to anyone else.
   - else

--- a/app/views/scrapers/data.atom.builder
+++ b/app/views/scrapers/data.atom.builder
@@ -1,6 +1,6 @@
 xml.instruct! :xml, :version => "1.0"
 xml.feed :xmlns => "http://www.w3.org/2005/Atom", "xmlns:dc" => "http://purl.org/dc/elements/1.1/" do
-  xml.title "Morph: #{@scraper.full_name}"
+  xml.title "morph.io: #{@scraper.full_name}"
   xml.subtitle @scraper.description
   xml.updated DateTime.parse(@scraper.updated_at.to_s).rfc3339
   xml.author do

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -55,7 +55,7 @@
 
       .col-md-6
         %blockquote
-          %p I love Morph because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
+          %p I love morph.io because it gives you everything you need to run a scraper. I've written a system which notifies me when Australian FOI disclosure logs are updated.
           %footer
             = link_to "https://morph.io/hailspuds", class: 'h-card media' do
               .pull-left

--- a/app/workers/create_scraper_worker.rb
+++ b/app/workers/create_scraper_worker.rb
@@ -20,7 +20,7 @@ class CreateScraperWorker
       # TODO Don't use hardcoded urls
       "README.md" => "This is a scraper that runs on [Morph](https://morph.io). To get started [see the documentation](https://morph.io/documentation)"
     )
-    scraper.add_commit_to_root_on_github(current_user, files, "Add template for Morph scraper")
+    scraper.add_commit_to_root_on_github(current_user, files, "Add template for morph.io scraper")
 
     # This block should happily run several times (after failures)
     scraper.create_scraper_progress.update("Get repository info", 60)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Send Morph mails to Cuttlefish (see http://cuttlefish.io)
+  # Send morph.io mails to Cuttlefish (see http://cuttlefish.io)
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     :address => (ENV["CUTTLEFISH_SERVER"] || "cuttlefish.io"),

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -5,7 +5,7 @@ ActiveAdmin.setup do |config|
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
   #
-  config.site_title = "Morph"
+  config.site_title = "morph.io"
 
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.

--- a/default_files/perl/template/scraper.pl
+++ b/default_files/perl/template/scraper.pl
@@ -1,4 +1,4 @@
-# This is a template for a Perl scraper on Morph (https://morph.io)
+# This is a template for a Perl scraper on morph.io (https://morph.io)
 # including some code snippets below that you should find helpful
 
 # use LWP::Simple;
@@ -30,7 +30,7 @@
 # }} @rows]);
 
 # You don't have to do things with the HTML::TreeBuilder and Database::DumpTruck
-# libraries. You can use whatever libraries are installed on Morph for Perl
+# libraries. You can use whatever libraries are installed on morph.io for Perl
 # (https://github.com/openaustralia/morph-docker-perl/blob/master/Dockerfile)
 # and all that matters is that your final data is written to an Sqlite
 # database called data.sqlite in the current working directory which has at

--- a/default_files/php/template/scraper.php
+++ b/default_files/php/template/scraper.php
@@ -1,5 +1,5 @@
 <?
-// This is a template for a PHP scraper on Morph (https://morph.io)
+// This is a template for a PHP scraper on morph.io (https://morph.io)
 // including some code snippets below that you should find helpful
 
 // require 'scraperwiki.php';
@@ -20,7 +20,7 @@
 // scraperwiki::select("* from data where 'name'='peter'")
 
 // You don't have to do things with the ScraperWiki library. You can use whatever is installed
-// on Morph for PHP (See https://github.com/openaustralia/morph-docker-php) and all that matters
+// on morph.io for PHP (See https://github.com/openaustralia/morph-docker-php) and all that matters
 // is that your final data is written to an Sqlite database called data.sqlite in the current working directory which
 // has at least a table called data.
 ?>

--- a/default_files/python/template/scraper.py
+++ b/default_files/python/template/scraper.py
@@ -1,4 +1,4 @@
-# This is a template for a Python scraper on Morph (https://morph.io)
+# This is a template for a Python scraper on morph.io (https://morph.io)
 # including some code snippets below that you should find helpful
 
 # import scraperwiki
@@ -18,6 +18,6 @@
 # scraperwiki.sql.select("* from data where 'name'='peter'")
 
 # You don't have to do things with the ScraperWiki and lxml libraries. You can use whatever libraries are installed
-# on Morph for Python (https://github.com/openaustralia/morph-docker-python/blob/master/pip_requirements.txt) and all that matters
+# on morph.io for Python (https://github.com/openaustralia/morph-docker-python/blob/master/pip_requirements.txt) and all that matters
 # is that your final data is written to an Sqlite database called data.sqlite in the current working directory which
 # has at least a table called data.

--- a/default_files/ruby/template/scraper.rb
+++ b/default_files/ruby/template/scraper.rb
@@ -1,4 +1,4 @@
-# This is a template for a Ruby scraper on Morph (https://morph.io)
+# This is a template for a Ruby scraper on morph.io (https://morph.io)
 # including some code snippets below that you should find helpful
 
 # require 'scraperwiki'
@@ -19,6 +19,6 @@
 # ScraperWiki.select("* from data where 'name'='peter'")
 
 # You don't have to do things with the Mechanize or ScraperWiki libraries. You can use whatever gems are installed
-# on Morph for Ruby (https://github.com/openaustralia/morph-docker-ruby/blob/master/Gemfile) and all that matters
+# on morph.io for Ruby (https://github.com/openaustralia/morph-docker-ruby/blob/master/Gemfile) and all that matters
 # is that your final data is written to an Sqlite database called data.sqlite in the current working directory which
 # has at least a table called data.

--- a/lib/morph/code_translate.rb
+++ b/lib/morph/code_translate.rb
@@ -1,6 +1,6 @@
 module Morph
   module CodeTranslate
-    # Translate Ruby code on ScraperWiki to something that will run on Morph
+    # Translate Ruby code on ScraperWiki to something that will run on morph.io
     def self.translate(language_key, code)
       case language_key
       when :ruby

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -30,12 +30,12 @@ module Morph
         c = Docker::Container.create(container_options, conn_interactive)
       rescue Excon::Errors::SocketError => e
         text = "Could not connect to Docker server: #{e}"
-        wrapper.call(:log, :internalerr, "Morph internal error: #{text}\n")
+        wrapper.call(:log, :internalerr, "morph.io internal error: #{text}\n")
         wrapper.call(:log, :internalerr, "Requeueing...\n")
         raise text
       rescue Docker::Error::NotFoundError => e
         text = "Could not find docker image #{options[:image_name]}"
-        wrapper.call(:log, :internalerr, "Morph internal error: #{text}\n")
+        wrapper.call(:log, :internalerr, "morph.io internal error: #{text}\n")
         wrapper.call(:log, :internalerr, "Requeueing...\n")
         raise text
       end
@@ -62,7 +62,7 @@ module Morph
         status_code = c.json["State"]["ExitCode"]
         puts "Docker container finished..."
       rescue Exception => e
-        wrapper.call(:log,  :internalerr, "Morph internal error: #{e}\n")
+        wrapper.call(:log,  :internalerr, "morph.io internal error: #{e}\n")
         wrapper.call(:log, :internalerr, "Stopping current container and requeueing\n")
         c.kill
         raise e

--- a/mitmproxy/log_to_morph.py
+++ b/mitmproxy/log_to_morph.py
@@ -21,7 +21,7 @@ def response(context, flow):
   try:
     s = urllib.urlopen(url, params)
     s.close()
-  # If we can't contact the morph server still handle this request.
+  # If we can't contact the morph.io server still handle this request.
   # If we let this exception pass up the chain the request would get dropped
   except IOError, e:
-    print "Error contacting Morph server:", e
+    print "Error contacting morph.io server:", e

--- a/spec/controllers/scrapers_controller_spec.rb
+++ b/spec/controllers/scrapers_controller_spec.rb
@@ -85,7 +85,7 @@ describe ScrapersController do
       sign_in user
     end
 
-    it 'should error if the scraper already exists on Morph' do
+    it 'should error if the scraper already exists on morph.io' do
       scraperwiki_double = double("Morph::Scraperwiki", exists?: true, private_scraper?: false, view?: false)
       Morph::Scraperwiki.should_receive(:new).at_least(:once).and_return(scraperwiki_double)
 
@@ -94,7 +94,7 @@ describe ScrapersController do
         post :create_scraperwiki, scraper: { name: 'my_scraper', owner_id: user.id, scraperwiki_shortname: 'my_scraper' }
       end
 
-      assigns(:scraper).errors[:name].should == ['is already taken on Morph']
+      assigns(:scraper).errors[:name].should == ['is already taken on morph.io']
     end
 
     it 'should error if the scraper already exists on GitHub' do
@@ -285,7 +285,7 @@ describe ScrapersController do
         response.should be_success
         body = Nokogiri::XML(response.body)
 
-        body.css("title").first.text.should == "Morph: mlandauer/a_scraper"
+        body.css("title").first.text.should == "morph.io: mlandauer/a_scraper"
         body.css("author name").first.text.should == "mlandauer"
         body.css("link").first[:href].should == "http://test.host/mlandauer/a_scraper"
 

--- a/spec/lib/morph/language_spec.rb
+++ b/spec/lib/morph/language_spec.rb
@@ -17,7 +17,7 @@ describe Morph::Language do
     it do
       ruby.scraper_templates(false).keys.should == ["scraper.rb"]
       ruby.scraper_templates(false)["scraper.rb"].should == <<-EOF
-# This is a template for a Ruby scraper on Morph (https://morph.io)
+# This is a template for a Ruby scraper on morph.io (https://morph.io)
 # including some code snippets below that you should find helpful
 
 # require 'scraperwiki'
@@ -38,7 +38,7 @@ describe Morph::Language do
 # ScraperWiki.select("* from data where 'name'='peter'")
 
 # You don't have to do things with the Mechanize or ScraperWiki libraries. You can use whatever gems are installed
-# on Morph for Ruby (https://github.com/openaustralia/morph-docker-ruby/blob/master/Gemfile) and all that matters
+# on morph.io for Ruby (https://github.com/openaustralia/morph-docker-ruby/blob/master/Gemfile) and all that matters
 # is that your final data is written to an Sqlite database called data.sqlite in the current working directory which
 # has at least a table called data.
       EOF
@@ -51,7 +51,7 @@ describe Morph::Language do
       php.scraper_templates(false).keys.should == ["scraper.php"]
       php.scraper_templates(false)["scraper.php"].should == <<-EOF
 <?
-// This is a template for a PHP scraper on Morph (https://morph.io)
+// This is a template for a PHP scraper on morph.io (https://morph.io)
 // including some code snippets below that you should find helpful
 
 // require 'scraperwiki.php';
@@ -72,7 +72,7 @@ describe Morph::Language do
 // scraperwiki::select("* from data where 'name'='peter'")
 
 // You don't have to do things with the ScraperWiki library. You can use whatever is installed
-// on Morph for PHP (See https://github.com/openaustralia/morph-docker-php) and all that matters
+// on morph.io for PHP (See https://github.com/openaustralia/morph-docker-php) and all that matters
 // is that your final data is written to an Sqlite database called data.sqlite in the current working directory which
 // has at least a table called data.
 ?>
@@ -82,7 +82,7 @@ describe Morph::Language do
     it do
       python.scraper_templates(false).keys.should == ["scraper.py"]
       python.scraper_templates(false)["scraper.py"].should == <<-EOF
-# This is a template for a Python scraper on Morph (https://morph.io)
+# This is a template for a Python scraper on morph.io (https://morph.io)
 # including some code snippets below that you should find helpful
 
 # import scraperwiki
@@ -102,7 +102,7 @@ describe Morph::Language do
 # scraperwiki.sql.select("* from data where 'name'='peter'")
 
 # You don't have to do things with the ScraperWiki and lxml libraries. You can use whatever libraries are installed
-# on Morph for Python (https://github.com/openaustralia/morph-docker-python/blob/master/pip_requirements.txt) and all that matters
+# on morph.io for Python (https://github.com/openaustralia/morph-docker-python/blob/master/pip_requirements.txt) and all that matters
 # is that your final data is written to an Sqlite database called data.sqlite in the current working directory which
 # has at least a table called data.
       EOF
@@ -111,7 +111,7 @@ describe Morph::Language do
     it do
       perl.scraper_templates(false).keys.should == ["scraper.pl"]
       perl.scraper_templates(false)["scraper.pl"].should == <<-EOF
-# This is a template for a Perl scraper on Morph (https://morph.io)
+# This is a template for a Perl scraper on morph.io (https://morph.io)
 # including some code snippets below that you should find helpful
 
 # use LWP::Simple;
@@ -143,7 +143,7 @@ describe Morph::Language do
 # }} @rows]);
 
 # You don't have to do things with the HTML::TreeBuilder and Database::DumpTruck
-# libraries. You can use whatever libraries are installed on Morph for Perl
+# libraries. You can use whatever libraries are installed on morph.io for Perl
 # (https://github.com/openaustralia/morph-docker-perl/blob/master/Dockerfile)
 # and all that matters is that your final data is written to an Sqlite
 # database called data.sqlite in the current working directory which has at

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -18,17 +18,17 @@ describe AlertMailer do
 
       it { email.from.should == ["contact@morph.io"]}
       it { email.to.should == ["matthew@oaf.org.au"]}
-      it { email.subject.should == "Morph: 1 scraper you are watching is erroring" }
+      it { email.subject.should == "morph.io: 1 scraper you are watching is erroring" }
     end
 
     context "two broken scrapers" do
       let(:broken_runs) { [run1, run2] }
       let(:email) { AlertMailer.alert_email(user, broken_runs, 32) }
 
-      it { email.subject.should == "Morph: 2 scrapers you are watching are erroring" }
+      it { email.subject.should == "morph.io: 2 scrapers you are watching are erroring" }
       it do
         email.text_part.body.to_s.should == <<-EOF
-Morph is letting you know that
+morph.io is letting you know that
 
 
 planningalerts-scrapers/spear errored
@@ -49,13 +49,13 @@ PHP Fatal error: Call to a member function find() on a non-object in /repo/scrap
 
 -----
 Annoyed by these emails? Then change what you're watching - http://dev.morph.io/users/mlandauer/watching?utm_medium=email&utm_source=alerts
-Morph.io - http://dev.morph.io/?utm_medium=email&utm_source=alerts
+morph.io - http://dev.morph.io/?utm_medium=email&utm_source=alerts
         EOF
       end
 
       it do
         expected = <<-EOF
-<a href="http://dev.morph.io/?utm_medium=email&amp;utm_source=alerts">Morph</a>
+<a href="http://dev.morph.io/?utm_medium=email&amp;utm_source=alerts">morph.io</a>
 is letting you know that
         EOF
         email.html_part.body.to_s.should include(expected)
@@ -90,7 +90,7 @@ It has been erroring for 3 days
 Annoyed by these emails? Then
 <a href="http://dev.morph.io/users/mlandauer/watching?utm_medium=email&amp;utm_source=alerts">change what you&#39;re watching</a>
 </p>
-<p><a href="http://dev.morph.io/?utm_medium=email&amp;utm_source=alerts">Morph.io</a></p>
+<p><a href="http://dev.morph.io/?utm_medium=email&amp;utm_source=alerts">morph.io</a></p>
         EOF
         email.html_part.body.to_s.should include(expected)
       end
@@ -100,7 +100,7 @@ Annoyed by these emails? Then
       it "should trunctate the log output" do
         run1.stub(error_text: "This is line one of an error\nThis is line two\nLine three\nLine four\nLine five\nLine six\n")
         AlertMailer.alert_email(user, [run1], 32).text_part.body.to_s.should == <<-EOF
-Morph is letting you know that
+morph.io is letting you know that
 
 
 planningalerts-scrapers/campbelltown errored
@@ -119,7 +119,7 @@ Line five
 
 -----
 Annoyed by these emails? Then change what you're watching - http://dev.morph.io/users/mlandauer/watching?utm_medium=email&utm_source=alerts
-Morph.io - http://dev.morph.io/?utm_medium=email&utm_source=alerts
+morph.io - http://dev.morph.io/?utm_medium=email&utm_source=alerts
         EOF
       end
     end

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Domain do
   describe "#update_meta!" do
     it do
-      resource = double(get: "<html><head><title>\nMorph   </title><meta name='Description' content='Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.'></head></html>")
+      resource = double(get: "<html><head><title>\nmorph.io   </title><meta name='Description' content='Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.'></head></html>")
       RestClient::Resource.should_receive(:new).with("http://morph.io", verify_ssl: OpenSSL::SSL::VERIFY_NONE).and_return(resource)
 
       domain = Domain.create!(name: "morph.io")
@@ -11,7 +11,7 @@ describe Domain do
       domain.reload
       domain.name.should == "morph.io"
       domain.meta.should == "Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud."
-      domain.title.should == "Morph"
+      domain.title.should == "morph.io"
     end
   end
 end


### PR DESCRIPTION
This changes the title of the site across the app, which we decided to do because it's quite snappy and consistent, and people seem to call it 'morph.io' anyway.

Closes #604