### PR TITLE
Search results pagination

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,8 +1,9 @@
 class SearchController < ApplicationController
   def search
     @q = params[:q]
-    @scrapers = Scraper.search(@q)
-    @owners = Owner.search(@q, highlight: {fields: [:nickname, :name, :company, :blog]})
+
+    @scrapers = Scraper.search @q, page: params[:page], per_page: 10
+    @owners = Owner.search @q, highlight: {fields: [:nickname, :name, :company, :blog]}, page: params[:page], per_page: 10
     @type = params[:type]
   end
 end

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -14,11 +14,11 @@
       %li{class: ('active' unless @type == "users"), role: "presentation"}
         = link_to search_path(q: @q, type: nil) do
           Scrapers
-          %span.badge #{@scrapers.size}
+          %span.badge #{@scrapers.total_count}
       %li{class: ('active' if @type == "users"), role: "presentation"}
         = link_to search_path(q: @q, type: "users") do
           Users
-          %span.badge #{@owners.size}
+          %span.badge #{@owners.total_count}
 
     - if @type == "users"
       .search-results

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -21,13 +21,11 @@
           %span.badge #{@owners.size}
 
     - if @type == "users"
-      = paginate @owners
       .search-results
         - @owners.with_details.each do |owner, details|
           = render owner, highlight: details[:highlight]
       = paginate @owners
     - else
-      = paginate @scrapers
       .search-results
         = render partial: "sync/scrapers/scraper", collection: @scrapers
       = paginate @scrapers


### PR DESCRIPTION
First pass of search results pagination. Set to 10 results per page, which seems like a good amount to scan quickly then click through.

closes #632 

![screen shot 2015-04-22 at 3 22 35 pm](https://cloud.githubusercontent.com/assets/1239550/7267768/975bcbaa-e903-11e4-9a13-2f07d48d8c15.png)

