### PR TITLE
make the user results more human and scanable

### DIFF
--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -38,4 +38,10 @@
     margin-top: 5px;
     color: $link-color;
   }
+
+  .owner-nickname {
+    margin-bottom: 5px;
+    display: block;
+    font-size: $font-size-large;
+  }
 }

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -24,6 +24,16 @@
   display: block;
   color: $text-color;
 
+  &:hover,
+  &:focus {
+    text-decoration: none;
+
+    .media-heading {
+      color: $link-hover-color;
+      text-decoration: $link-hover-decoration;
+    }
+  }
+
   + .owner-item {
     margin-top: 1.5em;
   }

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -22,17 +22,6 @@
 
 .owner-item {
   display: block;
-  color: $text-color;
-
-  &:hover,
-  &:focus {
-    text-decoration: none;
-
-    .media-heading {
-      color: $link-hover-color;
-      text-decoration: $link-hover-decoration;
-    }
-  }
 
   + .owner-item {
     margin-top: 1.5em;

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -34,6 +34,7 @@
   .media-heading {
     margin-top: 3px;
     color: $link-color;
+    font-weight: bold;
   }
 
   .owner-nickname {

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -22,6 +22,7 @@
 
 .owner-item {
   display: block;
+  color: $text-color;
 
   + .owner-item {
     margin-top: 1.5em;
@@ -35,5 +36,6 @@
 
   .media-heading {
     margin-top: 5px;
+    color: $link-color;
   }
 }

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -32,7 +32,7 @@
   }
 
   .media-heading {
-    margin-top: 5px;
+    margin-top: 3px;
     color: $link-color;
   }
 

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -21,8 +21,6 @@
 }
 
 .owner-item {
-  display: block;
-
   + .owner-item {
     margin-top: 1.5em;
   }

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -19,3 +19,11 @@
   padding-top: 15px;
   padding-bottom: 15px;
 }
+
+.owner-item {
+  display: block;
+
+  + .owner-item {
+    margin-top: 1.5em;
+  }
+}

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -26,4 +26,10 @@
   + .owner-item {
     margin-top: 1.5em;
   }
+
+  .media-left {
+    @media (min-width: $screen-sm-min) {
+      padding-right: 15px;
+    }
+  }
 }

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -32,4 +32,8 @@
       padding-right: 15px;
     }
   }
+
+  .media-heading {
+    margin-top: 5px;
+  }
 }

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -12,7 +12,7 @@
         - else
           = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       -# Hmmm... not sure I should just blindly mark it as safe
-      %strong= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+      %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       - if !organization.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : organization.company

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,23 +1,43 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to organization, class: "list-group-item" do
-  .row
-    .col-md-2
-      = owner_image(organization, 80, false)
-    .col-md-7
+= link_to organization, class: "list-group-item media" do
+  - if @q
+    .media-left
+      = owner_image(organization, 100, false)
+    .media-body
+      %h2.media-heading.h3
+        - if organization.name
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:name] ? highlight[:name].html_safe : organization.name
+        - else
+          %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       -# Hmmm... not sure I should just blindly mark it as safe
       %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
-      - if organization.name
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:name] ? highlight[:name].html_safe : organization.name
       - if !organization.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : organization.company
       - elsif !organization.blog.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:blog] ? highlight[:blog].html_safe : organization.blog
-    .col-md-3
-      - if organization.scrapers.count > 0
-        %div
-          Has
-          = pluralize(organization.scrapers.count, "scraper")
+
+  - else
+    .row
+      .col-md-2
+        = owner_image(organization, 80, false)
+      .col-md-7
+        -# Hmmm... not sure I should just blindly mark it as safe
+        %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+        - if organization.name
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:name] ? highlight[:name].html_safe : organization.name
+        - if !organization.company.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:company] ? highlight[:company].html_safe : organization.company
+        - elsif !organization.blog.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:blog] ? highlight[:blog].html_safe : organization.blog
+      .col-md-3
+        - if organization.scrapers.count > 0
+          %div
+            Has
+            = pluralize(organization.scrapers.count, "scraper")

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,6 +1,6 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to organization, class: "media" do
+= link_to organization, class: "owner-item media" do
   - if @q
     .media-left
       = owner_image(organization, 100, false)

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -12,7 +12,7 @@
         - else
           = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+      %strong= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       - if !organization.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : organization.company

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -5,8 +5,8 @@
     = link_to organization do
       = owner_image(organization, 60, false)
   .media-body
-    = link_to organization do
-      %h2.media-heading.h4
+    %h2.media-heading.h4
+      = link_to organization do
         - if !organization.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : organization.name

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -8,9 +8,9 @@
       %h2.media-heading.h3
         - if organization.name
           -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:name] ? highlight[:name].html_safe : organization.name
+          = highlight[:name] ? highlight[:name].html_safe : organization.name
         - else
-          %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+          = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       -# Hmmm... not sure I should just blindly mark it as safe
       %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       - if !organization.company.blank?

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -3,10 +3,10 @@
 %article.owner-item.media
   .media-left
     = link_to organization do
-      = owner_image(organization, 100, false)
+      = owner_image(organization, 60, false)
   .media-body
     = link_to organization do
-      %h2.media-heading.h3
+      %h2.media-heading.h4
         - if !organization.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : organization.name

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -6,7 +6,7 @@
       = owner_image(organization, 100, false)
     .media-body
       %h2.media-heading.h3
-        - if organization.name
+        - if !organization.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : organization.name
         - else

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,44 +1,20 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-- if @q
-  %article.owner-item.media
-    .media-left
-      = link_to organization do
-        = owner_image(organization, 100, false)
-    .media-body
-      = link_to organization do
-        %h2.media-heading.h3
-          - if !organization.name.blank?
-            -# Hmmm... not sure I should just blindly mark it as safe
-            = highlight[:name] ? highlight[:name].html_safe : organization.name
-          - else
-            = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+%article.owner-item.media
+  .media-left
+    = link_to organization do
+      = owner_image(organization, 100, false)
+  .media-body
+    = link_to organization do
+      %h2.media-heading.h3
+        - if !organization.name.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          = highlight[:name] ? highlight[:name].html_safe : organization.name
+        - else
+          = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
 
+    -# Hmmm... not sure I should just blindly mark it as safe
+    %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+    - if !organization.company.blank?
       -# Hmmm... not sure I should just blindly mark it as safe
-      %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
-      - if !organization.company.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:company] ? highlight[:company].html_safe : organization.company
-
-- else
-  = link_to organization do
-    .row
-      .col-md-2
-        = owner_image(organization, 80, false)
-      .col-md-7
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
-        - if organization.name
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:name] ? highlight[:name].html_safe : organization.name
-        - if !organization.company.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:company] ? highlight[:company].html_safe : organization.company
-        - elsif !organization.blog.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:blog] ? highlight[:blog].html_safe : organization.blog
-      .col-md-3
-        - if organization.scrapers.count > 0
-          %div
-            Has
-            = pluralize(organization.scrapers.count, "scraper")
+      %div= highlight[:company] ? highlight[:company].html_safe : organization.company

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,16 +1,19 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to organization, class: "owner-item media" do
-  - if @q
+- if @q
+  %article.owner-item.media
     .media-left
-      = owner_image(organization, 100, false)
+      = link_to organization do
+        = owner_image(organization, 100, false)
     .media-body
-      %h2.media-heading.h3
-        - if !organization.name.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          = highlight[:name] ? highlight[:name].html_safe : organization.name
-        - else
-          = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+      = link_to organization do
+        %h2.media-heading.h3
+          - if !organization.name.blank?
+            -# Hmmm... not sure I should just blindly mark it as safe
+            = highlight[:name] ? highlight[:name].html_safe : organization.name
+          - else
+            = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+
       -# Hmmm... not sure I should just blindly mark it as safe
       %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
       - if !organization.company.blank?
@@ -20,7 +23,8 @@
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:blog] ? highlight[:blog].html_safe : organization.blog
 
-  - else
+- else
+  = link_to organization do
     .row
       .col-md-2
         = owner_image(organization, 80, false)

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -19,9 +19,6 @@
       - if !organization.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : organization.company
-      - elsif !organization.blog.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:blog] ? highlight[:blog].html_safe : organization.blog
 
 - else
   = link_to organization do

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,6 +1,6 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to organization, class: "list-group-item media" do
+= link_to organization, class: "media" do
   - if @q
     .media-left
       = owner_image(organization, 100, false)

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -5,9 +5,9 @@
         %label Search
       .input-group.col-sm-12.col-md-8.col-lg-7
         = hidden_field_tag :type, @type
-        %input.form-control.input-lg#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+        %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
         .input-group-btn
-          %button.btn.btn-primary.btn-lg{type: "submit"} Search
+          %button.btn.btn-primary{type: "submit"} Search
 
   - if @q
     %ul.nav.nav-tabs

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,6 +1,6 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to user, class: "media" do
+= link_to user, class: "owner-item media" do
   - if @q
     .media-left
       = owner_image(user, 100, false)

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -13,7 +13,7 @@
           = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
 
       -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+      %strong= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
       - if !user.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : user.company

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -17,15 +17,6 @@
         - elsif !user.blog.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
-      .col-md-3
-        - if user.scrapers.count > 0
-          %div
-            Has
-            = pluralize(user.scrapers.count, "scraper")
-        - if user.other_scrapers_contributed_to.count > 0
-          %div
-            Contributed to
-            = pluralize(user.other_scrapers_contributed_to.count, "scraper")
 
   - else
     .row

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -19,9 +19,6 @@
       - if !user.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : user.company
-      - elsif !user.blog.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
 
 - else
   = link_to user do

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -13,7 +13,7 @@
           = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
 
       -# Hmmm... not sure I should just blindly mark it as safe
-      %strong= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+      %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
       - if !user.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : user.company

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -5,11 +5,15 @@
     .media-left
       = owner_image(user, 80, false)
     .media-body
+      %h2.media-heading.h3
+        - if user.name
+          -# Hmmm... not sure I should just blindly mark it as safe
+          = highlight[:name] ? highlight[:name].html_safe : user.name
+        - else
+          = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+
       -# Hmmm... not sure I should just blindly mark it as safe
       %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-      - if user.name
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:name] ? highlight[:name].html_safe : user.name
       - if !user.company.blank?
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:company] ? highlight[:company].html_safe : user.company

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -6,7 +6,7 @@
       = owner_image(user, 100, false)
     .media-body
       %h2.media-heading.h3
-        - if user.name
+        - if !user.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : user.name
         - else

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -5,8 +5,8 @@
     = link_to user do
       = owner_image(user, 60, false)
   .media-body
-    = link_to user do
-      %h2.media-heading.h4
+    %h2.media-heading.h4
+      = link_to user do
         - if !user.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : user.name

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,48 +1,21 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-- if @q
-  %article.owner-item.media
-    .media-left
-      = link_to user do
-        = owner_image(user, 100, false)
-    .media-body
-      = link_to user do
-        %h2.media-heading.h3
-          - if !user.name.blank?
-            -# Hmmm... not sure I should just blindly mark it as safe
-            = highlight[:name] ? highlight[:name].html_safe : user.name
-          - else
-            = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+%article.owner-item.media
+  .media-left
+    = link_to user do
+      = owner_image(user, 100, false)
+  .media-body
+    = link_to user do
+      %h2.media-heading.h3
+        - if !user.name.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          = highlight[:name] ? highlight[:name].html_safe : user.name
+        - else
+          = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
 
+    -# Hmmm... not sure I should just blindly mark it as safe
+    %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+    - if !user.company.blank?
       -# Hmmm... not sure I should just blindly mark it as safe
-      %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-      - if !user.company.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:company] ? highlight[:company].html_safe : user.company
-
-- else
-  = link_to user do
-    .row
-      .col-md-2
-        = owner_image(user, 80, false)
-      .col-md-7
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-        - if user.name
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:name] ? highlight[:name].html_safe : user.name
-        - if !user.company.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:company] ? highlight[:company].html_safe : user.company
-        - elsif !user.blog.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
-      .col-md-3
-        - if user.scrapers.count > 0
-          %div
-            Has
-            = pluralize(user.scrapers.count, "scraper")
-        - if user.other_scrapers_contributed_to.count > 0
-          %div
-            Contributed to
-            = pluralize(user.other_scrapers_contributed_to.count, "scraper")
+      %div= highlight[:company] ? highlight[:company].html_safe : user.company
+      

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,27 +1,54 @@
 - highlight = {} unless defined?(highlight) && highlight
 
 = link_to user, class: "list-group-item" do
-  .row
-    .col-md-2
-      = owner_image(user, 80, false)
-    .col-md-7
-      -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-      - if user.name
+  - if @q
+    .row
+      .col-md-2
+        = owner_image(user, 80, false)
+      .col-md-7
         -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:name] ? highlight[:name].html_safe : user.name
-      - if !user.company.blank?
+        %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+        - if user.name
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:name] ? highlight[:name].html_safe : user.name
+        - if !user.company.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:company] ? highlight[:company].html_safe : user.company
+        - elsif !user.blog.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
+      .col-md-3
+        - if user.scrapers.count > 0
+          %div
+            Has
+            = pluralize(user.scrapers.count, "scraper")
+        - if user.other_scrapers_contributed_to.count > 0
+          %div
+            Contributed to
+            = pluralize(user.other_scrapers_contributed_to.count, "scraper")
+
+  - else
+    .row
+      .col-md-2
+        = owner_image(user, 80, false)
+      .col-md-7
         -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:company] ? highlight[:company].html_safe : user.company
-      - elsif !user.blog.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
-    .col-md-3
-      - if user.scrapers.count > 0
-        %div
-          Has
-          = pluralize(user.scrapers.count, "scraper")
-      - if user.other_scrapers_contributed_to.count > 0
-        %div
-          Contributed to
-          = pluralize(user.other_scrapers_contributed_to.count, "scraper")
+        %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+        - if user.name
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:name] ? highlight[:name].html_safe : user.name
+        - if !user.company.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:company] ? highlight[:company].html_safe : user.company
+        - elsif !user.blog.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
+      .col-md-3
+        - if user.scrapers.count > 0
+          %div
+            Has
+            = pluralize(user.scrapers.count, "scraper")
+        - if user.other_scrapers_contributed_to.count > 0
+          %div
+            Contributed to
+            = pluralize(user.other_scrapers_contributed_to.count, "scraper")

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -3,10 +3,10 @@
 %article.owner-item.media
   .media-left
     = link_to user do
-      = owner_image(user, 100, false)
+      = owner_image(user, 60, false)
   .media-body
     = link_to user do
-      %h2.media-heading.h3
+      %h2.media-heading.h4
         - if !user.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : user.name

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,22 +1,21 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to user, class: "list-group-item" do
+= link_to user, class: "list-group-item media" do
   - if @q
-    .row
-      .col-md-2
-        = owner_image(user, 80, false)
-      .col-md-7
+    .media-left
+      = owner_image(user, 80, false)
+    .media-body
+      -# Hmmm... not sure I should just blindly mark it as safe
+      %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+      - if user.name
         -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-        - if user.name
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:name] ? highlight[:name].html_safe : user.name
-        - if !user.company.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:company] ? highlight[:company].html_safe : user.company
-        - elsif !user.blog.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
+        %div= highlight[:name] ? highlight[:name].html_safe : user.name
+      - if !user.company.blank?
+        -# Hmmm... not sure I should just blindly mark it as safe
+        %div= highlight[:company] ? highlight[:company].html_safe : user.company
+      - elsif !user.blog.blank?
+        -# Hmmm... not sure I should just blindly mark it as safe
+        %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
 
   - else
     .row

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,16 +1,18 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to user, class: "owner-item media" do
-  - if @q
+- if @q
+  %article.owner-item.media
     .media-left
-      = owner_image(user, 100, false)
+      = link_to user do
+        = owner_image(user, 100, false)
     .media-body
-      %h2.media-heading.h3
-        - if !user.name.blank?
-          -# Hmmm... not sure I should just blindly mark it as safe
-          = highlight[:name] ? highlight[:name].html_safe : user.name
-        - else
-          = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+      = link_to user do
+        %h2.media-heading.h3
+          - if !user.name.blank?
+            -# Hmmm... not sure I should just blindly mark it as safe
+            = highlight[:name] ? highlight[:name].html_safe : user.name
+          - else
+            = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
 
       -# Hmmm... not sure I should just blindly mark it as safe
       %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
@@ -21,7 +23,8 @@
         -# Hmmm... not sure I should just blindly mark it as safe
         %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
 
-  - else
+- else
+  = link_to user do
     .row
       .col-md-2
         = owner_image(user, 80, false)

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -3,7 +3,7 @@
 = link_to user, class: "list-group-item media" do
   - if @q
     .media-left
-      = owner_image(user, 80, false)
+      = owner_image(user, 100, false)
     .media-body
       %h2.media-heading.h3
         - if user.name

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,6 +1,6 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to user, class: "list-group-item media" do
+= link_to user, class: "media" do
   - if @q
     .media-left
       = owner_image(user, 100, false)


### PR DESCRIPTION
First pass of displaying users in search results. This simplifies the display by stripping out unnecessary information and decoration and giving the information some hierarchy. It makes the user's avatar slightly larger and puts the focus on their full name to emphasise the human.

If we want we could apply this style to the /users page as well by simply removing the 'if @q' logic in the _user.html.haml and _organisation.html.haml partials.

closes #633 

In a next iteration we might want to have 2 or 3 results per row, to get more to scan on the screen and use more of the available screen space. If we do that we might want to bring back the borders.

## Before
![screen shot 2015-04-22 at 6 42 19 pm](https://cloud.githubusercontent.com/assets/1239550/7270434/88c067c4-e91f-11e4-86b5-74bdac3305b7.png)
![screen shot 2015-04-22 at 6 42 40 pm](https://cloud.githubusercontent.com/assets/1239550/7270435/88c376ee-e91f-11e4-9133-8132ea5e09a0.png)

## After
![screen shot 2015-04-22 at 6 36 21 pm](https://cloud.githubusercontent.com/assets/1239550/7270453/9ec44b94-e91f-11e4-99a9-cd5d1b0ca419.png)
![screen shot 2015-04-22 at 6 36 30 pm](https://cloud.githubusercontent.com/assets/1239550/7270454/9ec67cfc-e91f-11e4-91b9-10d09906599d.png)
![screen shot 2015-04-22 at 6 40 18 pm](https://cloud.githubusercontent.com/assets/1239550/7270457/9ecee0fe-e91f-11e4-8a29-a33d9989c09f.png)
![screen shot 2015-04-22 at 6 40 26 pm](https://cloud.githubusercontent.com/assets/1239550/7270456/9ecc37f0-e91f-11e4-8907-5f4fda547bfb.png)
![screen shot 2015-04-22 at 6 40 45 pm](https://cloud.githubusercontent.com/assets/1239550/7270455/9ecbf1fa-e91f-11e4-98fc-31494402aa24.png)
