### PR TITLE
only index the owner data that is always displayed in search results

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -16,6 +16,11 @@ class Owner < ActiveRecord::Base
 
   serialize :feature_switches
 
+  # Specify the data searchkick should index
+  def search_data
+    as_json only: [:name, :nickname, :company, :blog]
+  end
+
   # TODO Fix up type conversion
   def buildpacks
     feature_switches[:buildpacks] == "1" if feature_switches.respond_to?(:has_key?)

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -18,7 +18,7 @@ class Owner < ActiveRecord::Base
 
   # Specify the data searchkick should index
   def search_data
-    as_json only: [:name, :nickname, :company, :blog]
+    as_json only: [:name, :nickname, :company]
   end
 
   # TODO Fix up type conversion


### PR DESCRIPTION
This restricts indexing to owner name, nickname, company. Stops of api key information or date created for example.

The owners blog url is sometimes shown, but not always, so I've removed that from the index.

Follows searchkick guide https://github.com/ankane/searchkick#indexing .

Before the change a search for contact@oaf.org.au returned the owner OpenAustralia Foundation, after change and reindexing the search returned nothing.