### PR TITLE
Make the user results more human and scanable - redux

### DIFF
--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -19,3 +19,27 @@
   padding-top: 15px;
   padding-bottom: 15px;
 }
+
+.owner-item {
+  + .owner-item {
+    margin-top: 1.5em;
+  }
+
+  .media-left {
+    @media (min-width: $screen-sm-min) {
+      padding-right: 15px;
+    }
+  }
+
+  .media-heading {
+    margin-top: 3px;
+    color: $link-color;
+    font-weight: bold;
+  }
+
+  .owner-nickname {
+    margin-bottom: 5px;
+    display: block;
+    font-size: $font-size-large;
+  }
+}

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -30,7 +30,7 @@
   }
 
   .media-heading {
-    margin-top: 3px;
+    margin-top: 6px;
     color: $link-color;
     font-weight: bold;
   }

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -21,9 +21,7 @@
 }
 
 .owner-item {
-  + .owner-item {
-    margin-top: 1.5em;
-  }
+  margin-top: 0;
 
   .media-left {
     @media (min-width: $screen-sm-min) {

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,20 +1,19 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-%article.owner-item.media
-  .media-left
-    = link_to organization do
+= link_to organization, class: 'list-group-item' do
+  %article.owner-item.media
+    .media-left
       = owner_image(organization, 60, false)
-  .media-body
-    %h2.media-heading.h4
-      = link_to organization do
+    .media-body
+      %h2.media-heading.h4
         - if !organization.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : organization.name
         - else
           = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
 
-    -# Hmmm... not sure I should just blindly mark it as safe
-    %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
-    - if !organization.company.blank?
       -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:company] ? highlight[:company].html_safe : organization.company
+      %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+      - if !organization.company.blank?
+        -# Hmmm... not sure I should just blindly mark it as safe
+        %div= highlight[:company] ? highlight[:company].html_safe : organization.company

--- a/app/views/organizations/_organization.html.haml
+++ b/app/views/organizations/_organization.html.haml
@@ -1,23 +1,20 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to organization, class: "list-group-item" do
-  .row
-    .col-md-2
-      = owner_image(organization, 80, false)
-    .col-md-7
+%article.owner-item.media
+  .media-left
+    = link_to organization do
+      = owner_image(organization, 60, false)
+  .media-body
+    %h2.media-heading.h4
+      = link_to organization do
+        - if !organization.name.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          = highlight[:name] ? highlight[:name].html_safe : organization.name
+        - else
+          = highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+
+    -# Hmmm... not sure I should just blindly mark it as safe
+    %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
+    - if !organization.company.blank?
       -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:nickname] ? highlight[:nickname].html_safe : organization.nickname
-      - if organization.name
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:name] ? highlight[:name].html_safe : organization.name
-      - if !organization.company.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:company] ? highlight[:company].html_safe : organization.company
-      - elsif !organization.blog.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:blog] ? highlight[:blog].html_safe : organization.blog
-    .col-md-3
-      - if organization.scrapers.count > 0
-        %div
-          Has
-          = pluralize(organization.scrapers.count, "scraper")
+      %div= highlight[:company] ? highlight[:company].html_safe : organization.company

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -5,9 +5,9 @@
         %label Search
       .input-group.col-sm-12.col-md-8.col-lg-7
         = hidden_field_tag :type, @type
-        %input.form-control.input-lg#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+        %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
         .input-group-btn
-          %button.btn.btn-primary.btn-lg{type: "submit"} Search
+          %button.btn.btn-primary{type: "submit"} Search
 
   - if @q
     %ul.nav.nav-tabs

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,21 +1,19 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-%article.owner-item.media
-  .media-left
-    = link_to user do
+= link_to user, class: 'list-group-item' do
+  %article.owner-item.media
+    .media-left
       = owner_image(user, 60, false)
-  .media-body
-    %h2.media-heading.h4
-      = link_to user do
+    .media-body
+      %h2.media-heading.h4
         - if !user.name.blank?
           -# Hmmm... not sure I should just blindly mark it as safe
           = highlight[:name] ? highlight[:name].html_safe : user.name
         - else
           = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
 
-    -# Hmmm... not sure I should just blindly mark it as safe
-    %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-    - if !user.company.blank?
       -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:company] ? highlight[:company].html_safe : user.company
-      
+      %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+      - if !user.company.blank?
+        -# Hmmm... not sure I should just blindly mark it as safe
+        %div= highlight[:company] ? highlight[:company].html_safe : user.company

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,27 +1,21 @@
 - highlight = {} unless defined?(highlight) && highlight
 
-= link_to user, class: "list-group-item" do
-  .row
-    .col-md-2
-      = owner_image(user, 80, false)
-    .col-md-7
+%article.owner-item.media
+  .media-left
+    = link_to user do
+      = owner_image(user, 60, false)
+  .media-body
+    %h2.media-heading.h4
+      = link_to user do
+        - if !user.name.blank?
+          -# Hmmm... not sure I should just blindly mark it as safe
+          = highlight[:name] ? highlight[:name].html_safe : user.name
+        - else
+          = highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+
+    -# Hmmm... not sure I should just blindly mark it as safe
+    %strong.owner-nickname= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
+    - if !user.company.blank?
       -# Hmmm... not sure I should just blindly mark it as safe
-      %div= highlight[:nickname] ? highlight[:nickname].html_safe : user.nickname
-      - if user.name
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:name] ? highlight[:name].html_safe : user.name
-      - if !user.company.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:company] ? highlight[:company].html_safe : user.company
-      - elsif !user.blog.blank?
-        -# Hmmm... not sure I should just blindly mark it as safe
-        %div= highlight[:blog] ? highlight[:blog].html_safe : user.blog
-    .col-md-3
-      - if user.scrapers.count > 0
-        %div
-          Has
-          = pluralize(user.scrapers.count, "scraper")
-      - if user.other_scrapers_contributed_to.count > 0
-        %div
-          Contributed to
-          = pluralize(user.other_scrapers_contributed_to.count, "scraper")
+      %div= highlight[:company] ? highlight[:company].html_safe : user.company
+      


### PR DESCRIPTION
Reopening #640.

TODO:

- [x] The way that users and scrapers are now shown in a list is inconsistent. Each item in the list should be separated by a line and the whole item should be a link.

Closes #633.