### PR TITLE
Don't run slow tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.0.0
-env: SECRET_KEY_BASE=859384
+env: SECRET_KEY_BASE=859384 RUN_SLOW_TESTS=true
 
 before_script:
   - cp config/database.travis.yml config/database.yml

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -2,3 +2,4 @@ test:
   adapter: mysql2
   database: scraping_test
   username: root
+  host: 127.0.0.1

--- a/spec/lib/morph/database_spec.rb
+++ b/spec/lib/morph/database_spec.rb
@@ -81,7 +81,7 @@ describe Morph::Database do
         Morph::Database.diffstat_table("foo", @db1, @db2).should == {added: 0, removed: 0, changed: 1, unchanged: 0}
       end
 
-      it "should be able to handle a large number of records" do
+      it "should be able to handle a large number of records", slow: true do
         FileUtils::rm_f(["tmp_db1.sqlite", "tmp_db2.sqlite"])
         # Create an sqlite database
         @db1 = SQLite3::Database.new("tmp_db1.sqlite")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
       DatabaseCleaner.clean
     end
   end
+
+  config.filter_run_excluding slow: true unless ENV["RUN_SLOW_TESTS"]
 end


### PR DESCRIPTION
This speeds up tests on my machine from 35 seconds to 5 seconds. The test that takes 30 seconds to run is still done on Travis.