### PR TITLE
show scraper language on search results

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -216,10 +216,17 @@ a i.fa-clock-o {
     margin: .2em 0 0 .25em;
     color: lighten($gray-light, 10%);
     font-weight: bold;
+    width: 4em;
+    text-align: right;
   }
 
   .icon-box {
     margin: 0 .25em;
+    text-align: center;
+
+    @media (min-width: $grid-float-breakpoint) {
+      width: 3em;
+    }
 
     .spinner,
     i {

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -213,10 +213,22 @@ a i.fa-clock-o {
   }
 
   .scraper-lang {
-    margin-top: .2em;
-    padding-left: .5em;
+    margin: .2em 0 0 .25em;
     color: lighten($gray-light, 10%);
     font-weight: bold;
+  }
+
+  .icon-box {
+    margin: 0 .25em;
+
+    .spinner,
+    i {
+     vertical-align: text-top;
+   }
+
+    + .icon-box {
+      margin: 0 .25em 0 .5em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -223,8 +223,8 @@ a i.fa-clock-o {
 
     .spinner,
     i {
-     vertical-align: text-top;
-   }
+      vertical-align: text-top;
+    }
 
     + .icon-box {
       margin: 0 .25em 0 .5em;

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -224,7 +224,7 @@ a i.fa-clock-o {
     margin: 0 .25em;
     text-align: center;
 
-    @media (min-width: $grid-float-breakpoint) {
+    @media (min-width: 37em) {
       width: 3em;
     }
 

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -211,6 +211,13 @@ a i.fa-clock-o {
   .full_name {
     word-break: break-all;
   }
+
+  .scraper-lang {
+    margin-top: .2em;
+    padding-left: .5em;
+    color: lighten($gray-light, 10%);
+    font-weight: bold;
+  }
 }
 
 h1.full_name {

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -236,6 +236,14 @@ a i.fa-clock-o {
     + .icon-box {
       margin: 0 .25em 0 .5em;
     }
+
+    // make sure layout is the same if
+    // there's no .scraper-lang element.
+    &:first-child {
+      @media (min-width: 30em) {
+        margin-right: 54px;
+      }
+    }
   }
 }
 

--- a/app/views/scrapers/_scraper.html.haml
+++ b/app/views/scrapers/_scraper.html.haml
@@ -2,6 +2,8 @@
 
 = link_to scraper, class: "list-group-item" do
   %div.scraper-block
+    - unless scraper.language.blank?
+      %small.scraper-lang.pull-right= scraper.language.human
     %strong.full_name= highlight[:full_name] ? highlight[:full_name].html_safe : scraper.full_name
     %div
       - unless scraper.description.blank?

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -1,6 +1,8 @@
-- cache ["v2", scraper] do
+- cache ["v3", scraper] do
   = link_to scraper, class: "list-group-item" do
     %div.scraper-block
+      - unless scraper.language.blank?
+        %small.scraper-lang.pull-right= scraper.language.human
       .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
       .icon-box.pull-right= render partial: "scrapers/auto_clock", locals: {scraper: scraper}
       - if scraper.last_run && scraper.last_run.finished_with_errors?

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -2,3 +2,4 @@ test:
   adapter: mysql2
   database: scraping_test
   username: root
+  host: 127.0.0.1


### PR DESCRIPTION
This adds the scraper language to the scraper element in search results, so citizens can quickly find scrapers they can work with in a language they can understand, when they are searching for scrapers.

This doesn't effect sync version of the scraper partial, used on the /scrapers page or owner show page, just the static version used in search results. Do we want to apply it on the sync version for consistency?

closes #639 

The style the language is faded, not the most salient element in the block, but clear on the righthand side of the scraper-item. This draws on Githubs style for showing the language of repos.

![screen shot 2015-04-28 at 10 50 06 am](https://cloud.githubusercontent.com/assets/1239550/7361105/929197ac-ed96-11e4-84e6-d505d7ad45d2.png)
![screen shot 2015-04-28 at 10 50 22 am](https://cloud.githubusercontent.com/assets/1239550/7361106/92c63b4c-ed96-11e4-84a8-b604faf0b3a5.png)

