### PR TITLE
Make the no results messages clearer

### DIFF
--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -10,34 +10,35 @@
           %button.btn.btn-primary{type: "submit"} Search
 
   - if @q
-    %ul.nav.nav-tabs
-      %li{class: ('active' unless @type == "users"), role: "presentation"}
-        = link_to search_path(q: @q, type: nil) do
-          Scrapers
-          %span.badge #{@scrapers.total_count}
-      %li{class: ('active' if @type == "users"), role: "presentation"}
-        = link_to search_path(q: @q, type: "users") do
-          Users
-          %span.badge #{@owners.total_count}
+    - if @scrapers.any? || @owners.any?
+      %ul.nav.nav-tabs
+        %li{class: ('active' unless @type == "users"), role: "presentation"}
+          = link_to search_path(q: @q, type: nil) do
+            Scrapers
+            %span.badge #{@scrapers.total_count}
+        %li{class: ('active' if @type == "users"), role: "presentation"}
+          = link_to search_path(q: @q, type: "users") do
+            Users
+            %span.badge #{@owners.total_count}
 
-    - if @type == "users"
-      .search-results
-        - @owners.with_details.each do |owner, details|
-          = render owner, highlight: details[:highlight]
-      = paginate @owners
+      - if @type == "users"
+        .search-results
+          - @owners.with_details.each do |owner, details|
+            = render owner, highlight: details[:highlight]
+        = paginate @owners
+      - else
+        .search-results
+          - @scrapers.with_details.each do |scraper, details|
+            = render scraper, highlight: details[:highlight]
+        = paginate @scrapers
+
+      - if @type == "users" && @owners.empty? && @scrapers.any?
+        Sorry, we couldn’t find any users relevant to your search term
+        %strong “#{@q}”.
+      - elsif @type != "users" && @scrapers.empty? && @owners.any?
+        Sorry, we couldn’t find any scrapers relevant to your search term
+        %strong “#{@q}”.
     - else
-      .search-results
-        - @scrapers.with_details.each do |scraper, details|
-          = render scraper, highlight: details[:highlight]
-      = paginate @scrapers
-
-    - if @type == "users" && @owners.empty? && @scrapers.any?
-      Sorry, we couldn’t find any users relevant to your search term
-      %strong “#{@q}”.
-    - elsif @type != "users" && @scrapers.empty? && @owners.any?
-      Sorry, we couldn’t find any scrapers relevant to your search term
-      %strong “#{@q}”.
-    - elsif @scrapers.empty? && @owners.empty?
       %h2 No results found
       %p
         Sorry, we couldn't find any scrapers or users relevant to your search term

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -33,11 +33,13 @@
         = paginate @scrapers
 
       - if @type == "users" && @owners.empty? && @scrapers.any?
-        Sorry, we couldn’t find any users relevant to your search term
-        %strong “#{@q}”.
+        .alert.alert-info
+          Sorry, we couldn’t find any users relevant to your search term
+          %strong “#{@q}”.
       - elsif @type != "users" && @scrapers.empty? && @owners.any?
-        Sorry, we couldn’t find any scrapers relevant to your search term
-        %strong “#{@q}”.
+        .alert.alert-info
+          Sorry, we couldn’t find any scrapers relevant to your search term
+          %strong “#{@q}”.
     - else
       %h2 No results found
       %p


### PR DESCRIPTION
This does 2 things to make it clearer when there are no search results.

closes #654 

## Zero Results
If there are zero results of any type, this removes the navigation tabs for search results types.

### Before
![screen shot 2015-04-28 at 2 44 02 pm](https://cloud.githubusercontent.com/assets/1239550/7362948/45097580-edb5-11e4-9ccb-9c37ad3af186.png)

### After
![screen shot 2015-04-28 at 2 43 22 pm](https://cloud.githubusercontent.com/assets/1239550/7362950/4a67fe2a-edb5-11e4-9757-1c097fd87c5e.png)

## No results of type
If there are results, but not of the type you have selected, this boosts up the 'no results of type' message with an alert appearance, in the style of the 'scraper has not yet been run' message on scrapers.

### Before
![screen shot 2015-04-28 at 2 44 34 pm](https://cloud.githubusercontent.com/assets/1239550/7362953/5e372cfa-edb5-11e4-8563-0d6705d5add4.png)

### After
![screen shot 2015-04-28 at 2 43 03 pm](https://cloud.githubusercontent.com/assets/1239550/7362955/6500a840-edb5-11e4-8de3-9797a8d598e4.png)