### PR TITLE
use the valid attribute `break-all` for `word-break`

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -49,7 +49,7 @@
   // with TableSaw
   .tablesaw-enhanced & .tablesaw > tbody > tr > td {
     white-space: normal;
-    word-break: break-word;
+    word-break: break-all;
 
     @media (min-width: $grid-float-breakpoint) {
       white-space: nowrap;


### PR DESCRIPTION
This fixes a bug where the row headings overlapped their bounds in firefox for small screens, described in #623.

Chrome was accepting the non-valid `break-word`, but trusty
firefox was demanding the valid css.

fixes #623