### PR TITLE
swap the order of scraper 'activity' icons in scraper lists

### DIFF
--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -3,8 +3,8 @@
     %div.scraper-block
       - unless scraper.language.blank?
         %small.scraper-lang.pull-right= scraper.language.human
-      .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
       .icon-box.pull-right= render partial: "scrapers/auto_clock", locals: {scraper: scraper}
+      .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
       - if scraper.last_run && scraper.last_run.finished_with_errors?
         %span.label.label-danger errored
       %strong.full_name= scraper.full_name


### PR DESCRIPTION
This means that the 'on timer' clock icon is on the right, next
to the scraper language text.

This should make it quicker to scan this information on scraper
lists.

fixes #665

## Before

![screen shot 2015-04-29 at 4 00 07 pm](https://cloud.githubusercontent.com/assets/1239550/7385423/1360ee6c-ee89-11e4-8ff6-c793e195cee7.png)


## After

![screen shot 2015-04-29 at 3 57 05 pm](https://cloud.githubusercontent.com/assets/1239550/7385424/19c9989e-ee89-11e4-820f-5fbc2a943728.png)
