### PR TITLE
[WIP] Show scraper usage

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -106,6 +106,30 @@
   ;
 }
 
+.data-header {
+  @include clearfix;
+  margin: 20px 0 0;
+
+  h3 {
+    margin-top: 0;
+
+    @media (min-width: 30em) {
+      display: inline-block;
+      float: left;
+      clear: left;
+    }
+  }
+
+  .scraper-data-usage {
+    @media (min-width: 30em) {
+      margin-top: 8px;
+      display: inline-block;
+      float: right;
+      clear: right;
+    }
+  }
+}
+
 .popover-content {
   word-wrap: break-word;
 }

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -115,17 +115,13 @@
 
     @media (min-width: 30em) {
       display: inline-block;
-      float: left;
-      clear: left;
     }
   }
 
   .scraper-data-usage {
     @media (min-width: 30em) {
-      margin-top: 8px;
+      margin: 8px 0 0 1em;
       display: inline-block;
-      float: right;
-      clear: right;
     }
   }
 }

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -29,7 +29,7 @@ class OwnersController < ApplicationController
 
   def update
     if @owner.user?
-      @owner.update_attributes(buildpacks: params[:user][:buildpacks])
+      @owner.update_attributes(buildpacks: params[:user][:buildpacks], see_downloads: params[:user][:see_downloads])
     elsif @owner.organization?
       @owner.update_attributes(buildpacks: params[:organization][:buildpacks])
     else

--- a/app/models/api_query.rb
+++ b/app/models/api_query.rb
@@ -1,4 +1,7 @@
 class ApiQuery < ActiveRecord::Base
+
+  belongs_to :scraper
+
   # disable STI
   self.inheritance_column = :_type_disabled
 

--- a/app/models/api_query.rb
+++ b/app/models/api_query.rb
@@ -1,6 +1,7 @@
 class ApiQuery < ActiveRecord::Base
 
   belongs_to :scraper
+  belongs_to :owner
 
   # disable STI
   self.inheritance_column = :_type_disabled

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -129,6 +129,7 @@ class Owner < ActiveRecord::Base
   end
 
   def scraper_download_count(scraper)
-   scraper.downloads.where(owner_id: id).count
+   scraper.api_queries.where(owner_id: id).count
+
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -21,19 +21,26 @@ class Owner < ActiveRecord::Base
     as_json only: [:name, :nickname, :company]
   end
 
-  # TODO Fix up type conversion
-  def buildpacks
-    if feature_switches.respond_to?(:has_key?) && feature_switches.has_key?(:buildpacks)
-      feature_switches[:buildpacks] == "1"
+  def get_feature_switch_value(key, default)
+    if feature_switches.respond_to?(:has_key?) && feature_switches.has_key?(key)
+      feature_switches[key] == "1"
     else
-      true
+      default
     end
   end
 
-  def buildpacks=(value)
+  def set_feature_switch_value(key, value)
     s = feature_switches || {}
-    s[:buildpacks] = value
+    s[key] = value
     self.feature_switches = s
+  end
+
+  def buildpacks
+    get_feature_switch_value(:buildpacks, true)
+  end
+
+  def buildpacks=(value)
+    set_feature_switch_value(:buildpacks, value)
   end
 
   def name

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -120,4 +120,8 @@ class Owner < ActiveRecord::Base
   def ability
     @ability ||= Ability.new(self)
   end
+
+  def scraper_download_count(scraper)
+   scraper.downloads.where(owner_id: id).count
+  end
 end

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -23,6 +23,8 @@ class Scraper < ActiveRecord::Base
 
   has_one :last_run, -> { order "queued_at DESC" }, class_name: "Run"
 
+  has_many :api_queries
+
   validates :name, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only have letters, numbers, '_' and '-'" }
   validates :owner, presence: true
   validates :name, uniqueness: { scope: :owner, message: 'is already taken on morph.io' }
@@ -42,12 +44,8 @@ class Scraper < ActiveRecord::Base
     (watchers + owner.watchers).uniq
   end
 
-  def downloads
-    ApiQuery.where(scraper_id: id)
-  end
-
   def downloaders
-    downloads.map do |d|
+    api_queries.map do |d|
       Owner.find(d.owner_id)
     end.uniq
   end

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -46,6 +46,12 @@ class Scraper < ActiveRecord::Base
     ApiQuery.where(scraper_id: id)
   end
 
+  def downloaders
+    downloads.map do |d|
+      Owner.find(d.owner_id)
+    end.uniq
+  end
+
   # Given a scraper name on github populates the fields for a morph.io scraper but doesn't save it
   def self.new_from_github(full_name, octokit_client)
     repo = octokit_client.repository(full_name)

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -45,9 +45,7 @@ class Scraper < ActiveRecord::Base
   end
 
   def downloaders
-    api_queries.map do |d|
-      Owner.find(d.owner_id)
-    end.uniq
+    api_queries.group(:owner_id).map {|d| d.owner}
   end
 
   # Given a scraper name on github populates the fields for a morph.io scraper but doesn't save it

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -42,6 +42,10 @@ class Scraper < ActiveRecord::Base
     (watchers + owner.watchers).uniq
   end
 
+  def downloads
+    ApiQuery.where(scraper_id: id)
+  end
+
   # Given a scraper name on github populates the fields for a morph.io scraper but doesn't save it
   def self.new_from_github(full_name, octokit_client)
     repo = octokit_client.repository(full_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,14 @@ class User < Owner
   has_many :contributions
   has_many :scrapers_contributed_to, through: :contributions, source: :scraper
 
+  def see_downloads
+    get_feature_switch_value(:see_downloads, false)
+  end
+
+  def see_downloads=(value)
+    set_feature_switch_value(:see_downloads, value)
+  end
+
   # In most cases people have contributed to the scrapers that they own so we really don't
   # want to see these twice. This method just removes their own scrapers from the list
   def other_scrapers_contributed_to

--- a/app/views/owners/settings.html.haml
+++ b/app/views/owners/settings.html.haml
@@ -34,4 +34,6 @@
 
     = simple_form_for @owner do |f|
       = f.input :buildpacks, as: :boolean, hint: "Add experimental support for Heroku buildpacks. Allows the installation of custom libraries, etc.."
+      - if @owner.user?
+        = f.input :see_downloads, as: :boolean, hint: "This user can see information on who downloaded what data, etc..."
       = f.button :submit, "Update feature settings"

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -8,7 +8,10 @@
         %p.scraper-data-usage
           %strong 1934 downloads
           by
-          %strong 3 users.
+          - # TODO: change this to show people/orgs who downloaded, not contributors
+          - scraper.contributors.each do |contributor|
+            = link_to contributor do
+              = owner_image(contributor, 30)
 
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -5,17 +5,18 @@
     - if active_table
       %header.data-header
         %h3 Data
-        %p.scraper-data-usage
-          %strong
-            Downloaded
-            = scraper.downloads.count
-            times
-          - if scraper.downloads.any?
-            by
-            - scraper.downloaders.each do |downloader|
-              = link_to downloader do
-                - tooltip_text = "Downloaded #{downloader.scraper_download_count(scraper)} times by #{downloader.name}"
-                = image_tag downloader.gravatar_url(30), title: tooltip_text, alt: downloader.name, class: 'img-circle has-tooltip'
+        - if current_user && current_user.see_downloads
+          %p.scraper-data-usage
+            %strong
+              Downloaded
+              = scraper.downloads.count
+              times
+            - if scraper.downloads.any?
+              by
+              - scraper.downloaders.each do |downloader|
+                = link_to downloader do
+                  - tooltip_text = "Downloaded #{downloader.scraper_download_count(scraper)} times by #{downloader.name}"
+                  = image_tag downloader.gravatar_url(30), title: tooltip_text, alt: downloader.name, class: 'img-circle has-tooltip'
 
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -4,6 +4,11 @@
 
     - if active_table
       %h3 Data
+      %p.scraper-data-usage
+        %strong 1934 downloads
+        by
+        %strong 3 users.
+
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|
           %li{class: ("active" if table == active_table)}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -8,10 +8,15 @@
         %p.scraper-data-usage
           %strong Downloaded 1934 times
           by
-          - # TODO: change this to show people/orgs who downloaded, not contributors
-          - scraper.contributors.each do |contributor|
-            = link_to contributor do
-              = owner_image(contributor, 30)
+          - # TODO: Replace this hardcoded stuff to show people/orgs who downloaded the scraper
+          %a{:href => "/ciudadanointeligente"}
+            %img.has-tooltip{:alt => "ciudadanointeligente", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "ciudadanointeligente", :height => "30", :src => "https://gravatar.com/avatar/15c938035f91373cb36062d6ad4ef2e5?d=https%3A%2F%2Fidenticons.github.com%2F6738e91db5a8843ba60d9147dd297d5a.png&r=x&s=30", :title => "", :width => "30"}/
+          %a{:href => "/jacksongs"}
+            %img.img-circle.has-tooltip{:alt => "jacksongs", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "jacksongs", :height => "30", :src => "https://avatars.githubusercontent.com/u/1189369?v=3&s=30", :title => "", :width => "30"}/
+          %a{:href => "/rezzo"}
+            %img.img-circle.has-tooltip{:alt => "rezzo", "data-container" => "body", "data-placement" => "bottom", "data-title" => "rezzo", :height => "30", :src => "https://avatars.githubusercontent.com/u/153339?v=3&s=30", :width => "30"}/
+          %a{:href => "/martinszy"}
+            %img.img-circle.has-tooltip{:alt => "martinszy", "data-container" => "body", "data-placement" => "bottom", "data-title" => "martinszy", :height => "30", :src => "https://avatars.githubusercontent.com/u/997732?v=3&s=30", :width => "30"}/
 
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -14,7 +14,8 @@
             by
             - scraper.downloaders.each do |downloader|
               = link_to downloader do
-                = image_tag downloader.gravatar_url(30), title: downloader.name, alt: downloader.name, class: 'img-circle'
+                - tooltip_text = "Downloaded #{downloader.scraper_download_count(scraper)} times by #{downloader.name}"
+                = image_tag downloader.gravatar_url(30), title: tooltip_text, alt: downloader.name, class: 'img-circle has-tooltip'
 
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -3,11 +3,12 @@
     - active_table = scraper.database.first_table_name
 
     - if active_table
-      %h3 Data
-      %p.scraper-data-usage
-        %strong 1934 downloads
-        by
-        %strong 3 users.
+      %header.data-header
+        %h3 Data
+        %p.scraper-data-usage
+          %strong 1934 downloads
+          by
+          %strong 3 users.
 
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -9,9 +9,9 @@
           %p.scraper-data-usage
             %strong
               Downloaded
-              = scraper.downloads.count
+              = scraper.api_queries.count
               times
-            - if scraper.downloads.any?
+            - if scraper.api_queries.any?
               by
               - scraper.downloaders.each do |downloader|
                 = link_to downloader do

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -6,7 +6,10 @@
       %header.data-header
         %h3 Data
         %p.scraper-data-usage
-          %strong Downloaded 1934 times
+          %strong
+            Downloaded
+            = scraper.downloads.count
+            times
           by
           - # TODO: Replace this hardcoded stuff to show people/orgs who downloaded the scraper
           %a{:href => "/ciudadanointeligente"}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -6,7 +6,7 @@
       %header.data-header
         %h3 Data
         %p.scraper-data-usage
-          %strong 1934 downloads
+          %strong Downloaded 1934 times
           by
           - # TODO: change this to show people/orgs who downloaded, not contributors
           - scraper.contributors.each do |contributor|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -10,16 +10,11 @@
             Downloaded
             = scraper.downloads.count
             times
-          by
-          - # TODO: Replace this hardcoded stuff to show people/orgs who downloaded the scraper
-          %a{:href => "/ciudadanointeligente"}
-            %img.has-tooltip{:alt => "ciudadanointeligente", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "Downloaded 5782 times by ciudadanointeligente", :height => "30", :src => "https://gravatar.com/avatar/15c938035f91373cb36062d6ad4ef2e5?d=https%3A%2F%2Fidenticons.github.com%2F6738e91db5a8843ba60d9147dd297d5a.png&r=x&s=30", :title => "", :width => "30"}/
-          %a{:href => "/jacksongs"}
-            %img.img-circle.has-tooltip{:alt => "jacksongs", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "jacksongs", :height => "30", :src => "https://avatars.githubusercontent.com/u/1189369?v=3&s=30", :title => "", :width => "30"}/
-          %a{:href => "/rezzo"}
-            %img.img-circle.has-tooltip{:alt => "rezzo", "data-container" => "body", "data-placement" => "bottom", "data-title" => "rezzo", :height => "30", :src => "https://avatars.githubusercontent.com/u/153339?v=3&s=30", :width => "30"}/
-          %a{:href => "/martinszy"}
-            %img.img-circle.has-tooltip{:alt => "martinszy", "data-container" => "body", "data-placement" => "bottom", "data-title" => "martinszy", :height => "30", :src => "https://avatars.githubusercontent.com/u/997732?v=3&s=30", :width => "30"}/
+          - if scraper.downloads.any?
+            by
+            - scraper.downloaders.each do |downloader|
+              = link_to downloader do
+                = image_tag downloader.gravatar_url(30), title: downloader.name, alt: downloader.name, class: 'img-circle'
 
       %ul.nav.nav-tabs
         - scraper.database.table_names.each do |table|

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -10,7 +10,7 @@
           by
           - # TODO: Replace this hardcoded stuff to show people/orgs who downloaded the scraper
           %a{:href => "/ciudadanointeligente"}
-            %img.has-tooltip{:alt => "ciudadanointeligente", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "ciudadanointeligente", :height => "30", :src => "https://gravatar.com/avatar/15c938035f91373cb36062d6ad4ef2e5?d=https%3A%2F%2Fidenticons.github.com%2F6738e91db5a8843ba60d9147dd297d5a.png&r=x&s=30", :title => "", :width => "30"}/
+            %img.has-tooltip{:alt => "ciudadanointeligente", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "Downloaded 5782 times by ciudadanointeligente", :height => "30", :src => "https://gravatar.com/avatar/15c938035f91373cb36062d6ad4ef2e5?d=https%3A%2F%2Fidenticons.github.com%2F6738e91db5a8843ba60d9147dd297d5a.png&r=x&s=30", :title => "", :width => "30"}/
           %a{:href => "/jacksongs"}
             %img.img-circle.has-tooltip{:alt => "jacksongs", "data-container" => "body", "data-original-title" => "", "data-placement" => "bottom", "data-title" => "jacksongs", :height => "30", :src => "https://avatars.githubusercontent.com/u/1189369?v=3&s=30", :title => "", :width => "30"}/
           %a{:href => "/rezzo"}


### PR DESCRIPTION
As a user, I want to know how much, and by who, the data I've scraped is being used, so that I can connect with people with similar interests, discover opportunities, know if there is interest in my work and what people are doing with it.

This adds a display of the *number of downloads of a scraper's data* and *number of people who've downloaded it*, to scraper show pages.

This is a static HTML prototype at the moment.

![screen shot 2015-04-30 at 2 29 50 pm](https://cloud.githubusercontent.com/assets/1239550/7406482/b86a2578-ef46-11e4-9d8a-efcc8c82aadf.png)
![screen shot 2015-04-30 at 2 25 30 pm](https://cloud.githubusercontent.com/assets/1239550/7406483/bb324268-ef46-11e4-9eca-a6b16e032857.png)
