### PR TITLE
simplify scraper code layout

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -205,6 +205,11 @@ a i.fa-clock-o {
   text-decoration: none;
 }
 
+.scraper-lang {
+  color: lighten($gray-light, 10%);
+  font-weight: bold;
+}
+
 .scraper-block {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -214,8 +219,6 @@ a i.fa-clock-o {
 
   .scraper-lang {
     margin: .2em 0 0 .25em;
-    color: lighten($gray-light, 10%);
-    font-weight: bold;
     width: 4em;
     text-align: right;
   }

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -71,6 +71,8 @@
       %h4
         %i.fa.fa-github-square.fa-lg
         Scraper code
+      - unless scraper.language.blank?
+        %strong.scraper-lang= scraper.language.human
       - if scraper.github_url
         %p
           %h5 Repository
@@ -80,8 +82,6 @@
           - if scraper.main_scraper_filename
             %h5 Main scraper
             #{link_to scraper.main_scraper_filename, scraper.github_url_main_scraper_file, target: "_blank"}
-            &mdash;
-            written in #{scraper.language.human}
     %p
       .form-group
         %label(for="git_url") git clone URL

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -75,13 +75,12 @@
         %strong.scraper-lang= scraper.language.human
       - if scraper.github_url
         %p
-          %h5 Repository
+
           = link_to scraper.github_url, target: "_blank" do
             = scraper.name
-            repo
           - if scraper.main_scraper_filename
-            %h5 Main scraper
-            #{link_to scraper.main_scraper_filename, scraper.github_url_main_scraper_file, target: "_blank"}
+            \/
+            = link_to scraper.main_scraper_filename, scraper.github_url_main_scraper_file, target: "_blank"
     %p
       .form-group
         %label(for="git_url") git clone URL


### PR DESCRIPTION
This changes simplifies the 'scraper code' section on the scraper page by:

* removing the 'repository' and 'main scraper' headings,
* displaying the repo and scraper file links inline in a 'reponame / filename.xx' format
* changes the language display to match the display in scraper lists

This makes the display of scrapers more consistent across the site.

relates to #664 

## Before
![screen shot 2015-05-01 at 2 58 16 pm](https://cloud.githubusercontent.com/assets/1239550/7426845/8a101abc-f012-11e4-817e-28a5c497f6ff.png)

## After
![screen shot 2015-05-01 at 2 58 10 pm](https://cloud.githubusercontent.com/assets/1239550/7426849/93668c5e-f012-11e4-948f-ac8e4d1e9e90.png)
