### PR TITLE
[WIP] Show scraped domains in scraper lists

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -230,6 +230,10 @@ a i.fa-clock-o {
   font-weight: bold;
 }
 
+.scraper-domains-list {
+  margin-bottom: 0;
+}
+
 .scraper-block {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -32,10 +32,10 @@ module RunsHelper
     d = run.scraped_domains.map{|d| h(d.name)}
     # If there are more than 3 in the list then summarise
     if d.count > 3
-      d = d[0..2] + [pluralize(d[3..-1].count, "other".html_safe)]
-      d.to_sentence.html_safe
+      d = d[0..2] + [pluralize(d[3..-1].count, "other")]
+      d.to_sentence
     else
-      d.join(", ").html_safe
+      d.join(", ")
     end
   end
 end

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -29,7 +29,12 @@ module RunsHelper
   end
 
   def scraped_domains_list(run)
-    d = run.scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}")}
+    scraped_domains = run.scraped_domains
+    scraped_domains_list2(scraped_domains)
+  end
+
+  def scraped_domains_list2(scraped_domains)
+    d = scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}")}
     # If there are more than 3 in the list then summarise
     summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
   end

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -19,21 +19,26 @@ module RunsHelper
     end
   end
 
+  # make an array never longer than 4 by summaring things on the end
+  def summary_of_array(array, summary_text)
+    if array.count > 3
+      array[0..2] + [pluralize(array.count - 3, summary_text)]
+    else
+      array
+    end
+  end
+
   def scraped_domains_list(run)
     d = run.scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}")}
     # If there are more than 3 in the list then summarise
-    if d.count > 3
-      d = d[0..2] + [pluralize(d[3..-1].count, "other domain".html_safe)]
-    end
-    d.to_sentence.html_safe
+    summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
   end
 
   def simplified_scraped_domains_list(run)
     d = run.scraped_domains.map{|d| h(d.name)}
     # If there are more than 3 in the list then summarise
     if d.count > 3
-      d = d[0..2] + [pluralize(d[3..-1].count, "other")]
-      d.to_sentence
+      summary_of_array(d, "other").to_sentence
     else
       d.join(", ")
     end

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -28,11 +28,6 @@ module RunsHelper
     end
   end
 
-  def scraped_domains_list(run)
-    scraped_domains = run.scraped_domains
-    scraped_domains_list2(scraped_domains)
-  end
-
   def scraped_domains_list2(scraped_domains)
     d = scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}")}
     # If there are more than 3 in the list then summarise

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -34,8 +34,8 @@ module RunsHelper
     summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
   end
 
-  def simplified_scraped_domains_list(run)
-    d = run.scraped_domains.map{|d| h(d.name)}
+  def simplified_scraped_domains_list(scraped_domains)
+    d = scraped_domains.map{|d| h(d.name)}
     # If there are more than 3 in the list then summarise
     if d.count > 3
       summary_of_array(d, "other").to_sentence

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -27,4 +27,15 @@ module RunsHelper
     end
     d.to_sentence.html_safe
   end
+
+  def simplified_scraped_domains_list(run)
+    d = run.scraped_domains.map{|d| h(d.name)}
+    # If there are more than 3 in the list then summarise
+    if d.count > 3
+      d = d[0..2] + [pluralize(d[3..-1].count, "other".html_safe)]
+      d.to_sentence.html_safe
+    else
+      d.join(", ").html_safe
+    end
+  end
 end

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -28,7 +28,7 @@ module RunsHelper
     end
   end
 
-  def scraped_domains_list2(scraped_domains)
+  def scraped_domains_list(scraped_domains)
     d = scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}")}
     # If there are more than 3 in the list then summarise
     summary_of_array(d, "other domain".html_safe).to_sentence.html_safe

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -40,6 +40,10 @@ class Scraper < ActiveRecord::Base
 
   delegate :queued?, :running?, to: :last_run, allow_nil: true
 
+  def scraped_domains
+    last_run ? last_run.scraped_domains : []
+  end
+
   def all_watchers
     (watchers + owner.watchers).uniq
   end

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -16,7 +16,7 @@
     - unless scraper.scraped_domains.empty?
       %p
         Scrapes
-        = scraped_domains_list2(scraper.last_run.scraped_domains)
+        = scraped_domains_list(scraper.last_run.scraped_domains)
       -# Only shows the meta info from the first domain
       -# TODO Figure out what to do with more than one domain
       %blockquote

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -16,7 +16,7 @@
     - unless scraper.scraped_domains.empty?
       %p
         Scrapes
-        = scraped_domains_list(scraper.last_run)
+        = scraped_domains_list2(scraper.last_run.scraped_domains)
       -# Only shows the meta info from the first domain
       -# TODO Figure out what to do with more than one domain
       %blockquote

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -13,7 +13,7 @@
 
     %h4= scraper.description
 
-    - if scraper.last_run && !scraper.last_run.scraped_domains.empty?
+    - unless scraper.scraped_domains.empty?
       %p
         Scrapes
         = scraped_domains_list(scraper.last_run)

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -16,7 +16,7 @@
     - unless scraper.scraped_domains.empty?
       %p
         Scrapes
-        = scraped_domains_list(scraper.last_run.scraped_domains)
+        = scraped_domains_list(scraper.scraped_domains)
       -# Only shows the meta info from the first domain
       -# TODO Figure out what to do with more than one domain
       %blockquote

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -20,7 +20,7 @@
       -# Only shows the meta info from the first domain
       -# TODO Figure out what to do with more than one domain
       %blockquote
-        %p= scraper.last_run.scraped_domains.first.meta_or_title
+        %p= scraper.scraped_domains.first.meta_or_title
 
     - unless scraper.owner.buildpacks
       %p.text-warning

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -11,5 +11,5 @@
       %div
         - unless scraper.description.blank?
           = scraper.description
-        %p.text-muted
+        %p.scraper-domains-list.text-muted
           Scrapes osom.cfa.vic.gov.au, ruralfire.qld.gov.au, sentinel.ga.gov.au, and 5 other domains.

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -11,3 +11,5 @@
       %div
         - unless scraper.description.blank?
           = scraper.description
+        %p.text-muted
+          Scrapes osom.cfa.vic.gov.au, ruralfire.qld.gov.au, sentinel.ga.gov.au, and 5 other domains.

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -12,4 +12,4 @@
         - unless scraper.description.blank?
           = scraper.description
         %p.scraper-domains-list.text-muted
-          Scrapes osom.cfa.vic.gov.au, ruralfire.qld.gov.au, sentinel.ga.gov.au, and 5 other domains.
+          osom.cfa.vic.gov.au, ruralfire.qld.gov.au, sentinel.ga.gov.au, and 5 others

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -11,5 +11,5 @@
       %div
         - unless scraper.description.blank?
           = scraper.description
-        %p.scraper-domains-list.text-muted
-          osom.cfa.vic.gov.au, ruralfire.qld.gov.au, sentinel.ga.gov.au, and 5 others
+        - unless scraper.scraped_domains.empty?
+          %p.scraper-domains-list.text-muted= simplified_scraped_domains_list(scraper.scraped_domains)

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -39,4 +39,43 @@ describe RunsHelper do
       expect(helper.scraped_domains_list(run)).to be_html_safe
     end
   end
+
+  describe "#simplified_scraped_domains_list" do
+    let(:run) { mock_model(Run) }
+    let(:foo_domain) { mock_model(Domain, name: "foo.com")}
+    let(:bar_domain) { mock_model(Domain, name: "bar.com")}
+    let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
+    let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com")}
+    let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
+
+    it do
+      allow(run).to receive(:scraped_domains).and_return([foo_domain])
+      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com'
+      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
+    end
+
+    it do
+      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain])
+      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com'
+      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
+    end
+
+    it do
+      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain])
+      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com'
+      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
+    end
+
+    it do
+      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain])
+      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com, and 1 other'
+      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
+    end
+
+    it do
+      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])
+      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com, and 2 others'
+      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
+    end
+  end
 end

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RunsHelper do
-  describe "#scraped_domains_list2" do
+  describe "#scraped_domains_list" do
     let(:foo_domain) { mock_model(Domain, name: "foo.com")}
     let(:bar_domain) { mock_model(Domain, name: "bar.com")}
     let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
@@ -9,28 +9,28 @@ describe RunsHelper do
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
 
     it do
-      expect(helper.scraped_domains_list2([foo_domain])).to eq '<a href="http://foo.com">foo.com</a>'
-      expect(helper.scraped_domains_list2([foo_domain])).to be_html_safe
+      expect(helper.scraped_domains_list([foo_domain])).to eq '<a href="http://foo.com">foo.com</a>'
+      expect(helper.scraped_domains_list([foo_domain])).to be_html_safe
     end
 
     it do
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain])).to eq '<a href="http://foo.com">foo.com</a> and <a href="http://bar.com">bar.com</a>'
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain])).to be_html_safe
+      expect(helper.scraped_domains_list([foo_domain, bar_domain])).to eq '<a href="http://foo.com">foo.com</a> and <a href="http://bar.com">bar.com</a>'
+      expect(helper.scraped_domains_list([foo_domain, bar_domain])).to be_html_safe
     end
 
     it do
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, and <a href="http://www.foo.com">www.foo.com</a>'
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
+      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, and <a href="http://www.foo.com">www.foo.com</a>'
+      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
     end
 
     it do
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 1 other domain'
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
+      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 1 other domain'
+      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
     end
 
     it do
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 2 other domains'
-      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
+      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 2 other domains'
+      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
     end
   end
 

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe RunsHelper do
-  describe "#scraped_domains_list" do
-    let(:run) { mock_model(Run) }
+  describe "#scraped_domains_list2" do
     let(:foo_domain) { mock_model(Domain, name: "foo.com")}
     let(:bar_domain) { mock_model(Domain, name: "bar.com")}
     let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
@@ -10,33 +9,28 @@ describe RunsHelper do
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain])
-      expect(helper.scraped_domains_list(run)).to eq '<a href="http://foo.com">foo.com</a>'
-      expect(helper.scraped_domains_list(run)).to be_html_safe
+      expect(helper.scraped_domains_list2([foo_domain])).to eq '<a href="http://foo.com">foo.com</a>'
+      expect(helper.scraped_domains_list2([foo_domain])).to be_html_safe
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain])
-      expect(helper.scraped_domains_list(run)).to eq '<a href="http://foo.com">foo.com</a> and <a href="http://bar.com">bar.com</a>'
-      expect(helper.scraped_domains_list(run)).to be_html_safe
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain])).to eq '<a href="http://foo.com">foo.com</a> and <a href="http://bar.com">bar.com</a>'
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain])).to be_html_safe
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain])
-      expect(helper.scraped_domains_list(run)).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, and <a href="http://www.foo.com">www.foo.com</a>'
-      expect(helper.scraped_domains_list(run)).to be_html_safe
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, and <a href="http://www.foo.com">www.foo.com</a>'
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain])
-      expect(helper.scraped_domains_list(run)).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 1 other domain'
-      expect(helper.scraped_domains_list(run)).to be_html_safe
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 1 other domain'
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])
-      expect(helper.scraped_domains_list(run)).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 2 other domains'
-      expect(helper.scraped_domains_list(run)).to be_html_safe
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq '<a href="http://foo.com">foo.com</a>, <a href="http://bar.com">bar.com</a>, <a href="http://www.foo.com">www.foo.com</a>, and 2 other domains'
+      expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
     end
   end
 

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -51,31 +51,26 @@ describe RunsHelper do
     it do
       allow(run).to receive(:scraped_domains).and_return([foo_domain])
       expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com'
-      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
     end
 
     it do
       allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain])
       expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com'
-      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
     end
 
     it do
       allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain])
       expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com'
-      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
     end
 
     it do
       allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain])
       expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com, and 1 other'
-      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
     end
 
     it do
       allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])
       expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com, and 2 others'
-      expect(helper.simplified_scraped_domains_list(run)).to be_html_safe
     end
   end
 end

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -35,7 +35,6 @@ describe RunsHelper do
   end
 
   describe "#simplified_scraped_domains_list" do
-    let(:run) { mock_model(Run) }
     let(:foo_domain) { mock_model(Domain, name: "foo.com")}
     let(:bar_domain) { mock_model(Domain, name: "bar.com")}
     let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
@@ -43,28 +42,23 @@ describe RunsHelper do
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain])
-      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com'
+      expect(helper.simplified_scraped_domains_list([foo_domain])).to eq 'foo.com'
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain])
-      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com'
+      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain])).to eq 'foo.com, bar.com'
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain])
-      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com'
+      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, www.foo.com'
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain])
-      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com, and 1 other'
+      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other'
     end
 
     it do
-      allow(run).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])
-      expect(helper.simplified_scraped_domains_list(run)).to eq 'foo.com, bar.com, www.foo.com, and 2 others'
+      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 others'
     end
   end
 end

--- a/spec/models/scraper_spec.rb
+++ b/spec/models/scraper_spec.rb
@@ -37,7 +37,7 @@ describe Scraper do
     describe "#scraperwiki_url" do
       it do
         @scraper.scraperwiki_shortname = "australian_rainfall"
-        @scraper.scraperwiki_url.should == "https://classic.scraperwiki.com/scrapers/australian_rainfall/" 
+        @scraper.scraperwiki_url.should == "https://classic.scraperwiki.com/scrapers/australian_rainfall/"
       end
 
       it do

--- a/spec/models/scraper_spec.rb
+++ b/spec/models/scraper_spec.rb
@@ -116,4 +116,25 @@ describe Scraper do
       end
     end
   end
+
+  describe "#scraped_domains" do
+    let(:scraper) { Scraper.new }
+    let(:last_run) { mock_model(Run) }
+
+    it "should return an empty array if there is no last run" do
+      expect(scraper.scraped_domains).to eq []
+    end
+
+    context "there is a last run" do
+      before :each do
+        allow(scraper).to receive(:last_run).and_return(last_run)
+      end
+
+      it "should defer to the last run" do
+        result = mock
+        expect(last_run).to receive(:scraped_domains).and_return(result)
+        expect(scraper.scraped_domains).to eq result
+      end
+    end
+  end
 end


### PR DESCRIPTION
Knowing what domains are being scraped is an important and useful piece of information for understanding what a scraper does. Showing this information in the scraper lists should help citizens
find the scrapers they are looking for, in some cases more than the scraper's title.

I've added a static prototype of what this could look like. I took the text initially from how it is displayed on the show page but it was very busy with the full 'Scrapes ...' sentence structure. In d683a9e I stripped it back to just the domain information.

I couldn't get morph to show domains on any pages in my local version, so I couldn't make this dynamic unfortunately :S @mlandauer could you tell me how to get that to run or make this dynamic please?

Here's what this could look like when implemented:

![screen shot 2015-05-03 at 5 30 28 pm](https://cloud.githubusercontent.com/assets/1239550/7444280/542a2a84-f1be-11e4-9447-36bf44c054b2.png)

I think it makes #674 more urgent as the headings loose some of their prominence with this.

closes #66

Get's the list ready for #509