### PR TITLE
Move error label to the righthand side in scraper lists

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -268,6 +268,10 @@ a i.fa-clock-o {
       }
     }
   }
+
+  .label-danger.pull-right {
+    margin-left: 0.25em;
+  }
 }
 
 h1.full_name {

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -1,4 +1,4 @@
-- cache ["v3", scraper] do
+- cache ["v4", scraper] do
   = link_to scraper, class: "list-group-item" do
     %div.scraper-block
       - unless scraper.language.blank?

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -4,6 +4,8 @@
       - unless scraper.language.blank?
         %small.scraper-lang.pull-right= scraper.language.human
       .icon-box.pull-right= render partial: "scrapers/auto_clock", locals: {scraper: scraper}
+      -# TODO Refactor this so that we're not duplicating logic of checking queued and running
+      -# here as well as in "scrapers/running_indicator" partial
       - if scraper.queued? || scraper.running?
         .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
       - elsif scraper.last_run && scraper.last_run.finished_with_errors?

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -4,8 +4,9 @@
       - unless scraper.language.blank?
         %small.scraper-lang.pull-right= scraper.language.human
       .icon-box.pull-right= render partial: "scrapers/auto_clock", locals: {scraper: scraper}
-      .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
-      - if scraper.last_run && scraper.last_run.finished_with_errors?
+      - if scraper.queued? || scraper.running?
+        .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
+      - elsif scraper.last_run && scraper.last_run.finished_with_errors?
         %span.label.label-danger.pull-right errored
       %strong.full_name= scraper.full_name
       %div

--- a/app/views/sync/scrapers/_scraper.html.haml
+++ b/app/views/sync/scrapers/_scraper.html.haml
@@ -6,7 +6,7 @@
       .icon-box.pull-right= render partial: "scrapers/auto_clock", locals: {scraper: scraper}
       .icon-box.pull-right= render partial: "scrapers/running_indicator", locals: {scraper: scraper}
       - if scraper.last_run && scraper.last_run.finished_with_errors?
-        %span.label.label-danger errored
+        %span.label.label-danger.pull-right errored
       %strong.full_name= scraper.full_name
       %div
         - unless scraper.description.blank?


### PR DESCRIPTION
The 'errored' label indents the heading in scraper lists, taking too much prominence (see #689 ). These changes move it to the righthand right and show it in the place where the 'running' icon would sit. 

This makes the layout simpler and easier to read by grouping all the scraper activity/status information together.

![screen shot 2015-05-04 at 9 07 25 am](https://cloud.githubusercontent.com/assets/1239550/7447385/14f18090-f23d-11e4-8e78-13f0fcd17a21.png)