### PR TITLE
Add more visual structure to scraper lists by making the titles more prominent

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -237,6 +237,10 @@ a i.fa-clock-o {
   .full_name {
     word-break: break-all;
     color: $link-color;
+
+    @media (min-width: 40em) {
+      font-size: $font-size-h4;
+    }
   }
 
   a:hover & .full_name,

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -236,6 +236,12 @@ a i.fa-clock-o {
 
   .full_name {
     word-break: break-all;
+    color: $link-color;
+  }
+
+  a:hover & .full_name,
+  a:focus & .full_name {
+    color: $link-hover-color;
   }
 
   .scraper-lang {

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -233,6 +233,7 @@ a i.fa-clock-o {
 .scraper-block {
   overflow: hidden;
   text-overflow: ellipsis;
+
   .full_name {
     word-break: break-all;
   }


### PR DESCRIPTION
At the moment the scraper lists are quite flat, which out too much visual distinction between titles and descriptions (titles are bold):
![screen shot 2015-05-04 at 10 11 05 am](https://cloud.githubusercontent.com/assets/1239550/7447622/3e73c73a-f246-11e4-86f2-022ce5249233.png)

To make these lists more inviting, readable and consistent with user lists, these changes give the scraper headings a link colour and make them bigger:
![screen shot 2015-05-04 at 10 11 25 am](https://cloud.githubusercontent.com/assets/1239550/7447628/69c2843a-f246-11e4-8d23-bc7538440b4d.png)

closes #674 