### PR TITLE
[WIP] Search banner for signed in landing page

### DIFF
--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -12,6 +12,11 @@
 }
 
 .banner-search {
+  @media (min-width: $screen-md-min) {
+    padding-bottom: 24px;
+    padding-top: 24px;
+  }
+
   .label-heading {
     font-size: $font-size-h4;
 

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -31,6 +31,10 @@
     @media (min-width: $screen-md-min) {
       font-size: $font-size-h1;
     }
+
+    .pre-heading {
+      margin-bottom: .2em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -11,6 +11,10 @@
   }
 }
 
+.search-suggestions {
+  margin-top: .75em;
+}
+
 .banner-wrapper {
   background-color: #716b58;
 }

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -11,6 +11,24 @@
   }
 }
 
+.banner-search {
+  .label-heading {
+    font-size: $font-size-h4;
+
+    @media (min-width: $screen-xs-min) {
+      font-size: $font-size-h3;
+    }
+
+    @media (min-width: $screen-sm-min) {
+      font-size: $font-size-h2;
+    }
+
+    @media (min-width: $screen-md-min) {
+      font-size: $font-size-h1;
+    }
+  }
+}
+
 .search-suggestions {
   margin-top: .75em;
 }

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -36,6 +36,10 @@
 
 .search-suggestions {
   margin-top: .75em;
+
+  @media (min-width: $screen-md-min) {
+    font-size: 1.125em;
+  }
 }
 
 .banner-wrapper {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -6,6 +6,7 @@
 @import "font-awesome";
 @import "vendor/tablesaw.stackonly";
 
+@import "global/typography";
 @import "global/site-header";
 @import "global/alerts";
 @import "bootstrap_and_overrides";

--- a/app/assets/stylesheets/global/_typography.scss
+++ b/app/assets/stylesheets/global/_typography.scss
@@ -1,0 +1,3 @@
+.pre-heading {
+  display: block;
+}

--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -2,7 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.search-header {
+.search-form {
   margin-bottom: 2em;
 
 }

--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -5,9 +5,10 @@
 .search-header {
   margin-bottom: 2em;
 
-  + .nav-tabs {
-    margin-bottom: 2em;
-  }
+}
+
+.search-type-nav {
+  margin-bottom: 2em;
 }
 
 .search-results em {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,8 @@ module ApplicationHelper
     l = Morph::Language.new(key)
     image_tag(l.image_path, options) + " " + l.human
   end
+
+  def floor_to_hundreds(number)
+    (number / 100.0).floor * 100
+  end
 end

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -1,13 +1,12 @@
-.search-header
-  =form_tag search_path, method: "get", class: "form-inline" do
-    %label.sr-only{for: "query"} Search
-    .input-group.col-sm-12.col-md-9.col-lg-8
-      = hidden_field_tag :type, @type
-      %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
-      .input-group-btn
-        %button.btn.btn-primary{type: "submit"} Search
-    - if @q.blank?
-      %p.search-suggestions
-        Try #{link_to "parliament", search_path(q: "parliament")},
-        #{ link_to "gov.uk", search_path(q: "gov.uk")} or
-        #{ link_to "slovakia", search_path(q: "slovakia")}
+=form_tag search_path, method: "get", class: "search-form form-inline" do
+  %label.sr-only{for: "query"} Search
+  .input-group.col-sm-12.col-md-9.col-lg-8
+    = hidden_field_tag :type, @type
+    %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+    .input-group-btn
+      %button.btn.btn-primary{type: "submit"} Search
+  - if @q.blank?
+    %p.search-suggestions
+      Try #{link_to "parliament", search_path(q: "parliament")},
+      #{ link_to "gov.uk", search_path(q: "gov.uk")} or
+      #{ link_to "slovakia", search_path(q: "slovakia")}

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -17,4 +17,3 @@
             Try #{link_to "parliament", search_path(q: "parliament")},
             #{ link_to "planning", search_path(q: "planning")} or
             #{ link_to "Ghana", search_path(q: "Ghana")}
-

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -1,8 +1,6 @@
 .search-header
   =form_tag search_path, method: "get", class: "form-inline" do
-    %h1.label-heading
-      %small.pre-heading Find data and code you can use
-      %label Search over #{pluralize(Scraper.count, "scraper")}
+    %label.sr-only{for: "query"} Search
     .input-group.col-sm-12.col-md-9.col-lg-8
       = hidden_field_tag :type, @type
       %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -4,7 +4,9 @@
       =form_tag search_path, method: "get", class: "form-inline" do
         %h1.label-heading
           %small.pre-heading Find data and code you can use
-          %label Search over #{pluralize(Scraper.count, "scraper")}
+          %label
+            Search over
+            = pluralize(floor_to_hundreds(Scraper.count), "scraper")
         .input-group.col-sm-12.col-md-9.col-lg-8
           = hidden_field_tag :type, @type
           %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -10,8 +10,9 @@
           %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
           .input-group-btn
             %button.btn.btn-primary{type: "submit"} Search
-        %p.search-suggestions
-          Try #{link_to "parliament", search_path(q: "parliament")},
-          #{ link_to "planning", search_path(q: "planning")} or
-          #{ link_to "Ghana", search_path(q: "Ghana")}
+        - if @q.blank?
+          %p.search-suggestions
+            Try #{link_to "parliament", search_path(q: "parliament")},
+            #{ link_to "planning", search_path(q: "planning")} or
+            #{ link_to "Ghana", search_path(q: "Ghana")}
 

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -1,19 +1,15 @@
-.banner-search.banner
-  .container
-    .search-header
-      =form_tag search_path, method: "get", class: "form-inline" do
-        %h1.label-heading
-          %small.pre-heading Find data and code you can use
-          %label
-            Search over
-            = pluralize(floor_to_hundreds(Scraper.count), "scraper")
-        .input-group.col-sm-12.col-md-9.col-lg-8
-          = hidden_field_tag :type, @type
-          %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
-          .input-group-btn
-            %button.btn.btn-primary{type: "submit"} Search
-        - if @q.blank?
-          %p.search-suggestions
-            Try #{link_to "parliament", search_path(q: "parliament")},
-            #{ link_to "gov.uk", search_path(q: "gov.uk")} or
-            #{ link_to "slovakia", search_path(q: "slovakia")}
+.search-header
+  =form_tag search_path, method: "get", class: "form-inline" do
+    %h1.label-heading
+      %small.pre-heading Find data and code you can use
+      %label Search over #{pluralize(Scraper.count, "scraper")}
+    .input-group.col-sm-12.col-md-9.col-lg-8
+      = hidden_field_tag :type, @type
+      %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+      .input-group-btn
+        %button.btn.btn-primary{type: "submit"} Search
+    - if @q.blank?
+      %p.search-suggestions
+        Try #{link_to "parliament", search_path(q: "parliament")},
+        #{ link_to "gov.uk", search_path(q: "gov.uk")} or
+        #{ link_to "slovakia", search_path(q: "slovakia")}

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -15,5 +15,5 @@
         - if @q.blank?
           %p.search-suggestions
             Try #{link_to "parliament", search_path(q: "parliament")},
-            #{ link_to "planning", search_path(q: "planning")} or
-            #{ link_to "Ghana", search_path(q: "Ghana")}
+            #{ link_to "gov.uk", search_path(q: "gov.uk")} or
+            #{ link_to "slovakia", search_path(q: "slovakia")}

--- a/app/views/application/_search_banner.html.haml
+++ b/app/views/application/_search_banner.html.haml
@@ -1,0 +1,17 @@
+.banner-search.banner
+  .container
+    .search-header
+      =form_tag search_path, method: "get", class: "form-inline" do
+        %h1.label-heading
+          %small.pre-heading Find data and code you can use
+          %label Search over #{pluralize(Scraper.count, "scraper")}
+        .input-group.col-sm-12.col-md-9.col-lg-8
+          = hidden_field_tag :type, @type
+          %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+          .input-group-btn
+            %button.btn.btn-primary{type: "submit"} Search
+        %p.search-suggestions
+          Try #{link_to "parliament", search_path(q: "parliament")},
+          #{ link_to "planning", search_path(q: "planning")} or
+          #{ link_to "Ghana", search_path(q: "Ghana")}
+

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -3,7 +3,7 @@
 .container
   - if @q
     - if @scrapers.any? || @owners.any?
-      %ul.nav.nav-tabs
+      %ul.search-type-nav.nav.nav-tabs
         %li{class: ('active' unless @type == "users"), role: "presentation"}
           = link_to search_path(q: @q, type: nil) do
             Scrapers

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,14 +1,6 @@
-.container
-  .search-header
-    =form_tag search_path, method: "get", class: "form-inline" do
-      %h1.label-heading
-        %label Search
-      .input-group.col-sm-12.col-md-8.col-lg-7
-        = hidden_field_tag :type, @type
-        %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
-        .input-group-btn
-          %button.btn.btn-primary{type: "submit"} Search
+= render partial: "search_banner"
 
+.container
   - if @q
     - if @scrapers.any? || @owners.any?
       %ul.nav.nav-tabs

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,4 +1,6 @@
 .container
+  %h1.label-heading
+    Search
   = render partial: "search_banner"
 
   - if @q

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,6 +1,6 @@
-= render partial: "search_banner"
-
 .container
+  = render partial: "search_banner"
+
   - if @q
     - if @scrapers.any? || @owners.any?
       %ul.search-type-nav.nav.nav-tabs

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -1,17 +1,18 @@
-.container
-  .search-header
-    =form_tag search_path, method: "get", class: "form-inline" do
-      %h1.label-heading
-        %label Search over 2000 scrapers
-      .input-group.col-sm-12.col-md-8.col-lg-7
-        = hidden_field_tag :type, @type
-        %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
-        .input-group-btn
-          %button.btn.btn-primary{type: "submit"} Search
-      %p
-        try #{link_to "parliament", search_path(q: "parliament")},
-        #{ link_to "planning", search_path(q: "planning")} or
-        #{ link_to "Ghana", search_path(q: "Ghana")}
+.banner-search.banner
+  .container
+    .search-header
+      =form_tag search_path, method: "get", class: "form-inline" do
+        %h1.label-heading
+          %label Search over 2000 scrapers
+        .input-group.col-sm-12.col-md-8.col-lg-7
+          = hidden_field_tag :type, @type
+          %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+          .input-group-btn
+            %button.btn.btn-primary{type: "submit"} Search
+        %p
+          try #{link_to "parliament", search_path(q: "parliament")},
+          #{ link_to "planning", search_path(q: "planning")} or
+          #{ link_to "Ghana", search_path(q: "Ghana")}
 
 .container
   .row

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -1,5 +1,8 @@
 .banner-search.banner
   .container
+    %h1.label-heading
+      %small.pre-heading Find data and code you can use
+      Search over #{pluralize(floor_to_hundreds(Scraper.count), "scraper")}
     = render partial: "search_banner"
 
 .container

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -1,19 +1,4 @@
-.banner-search.banner
-  .container
-    .search-header
-      =form_tag search_path, method: "get", class: "form-inline" do
-        %h1.label-heading
-          %small.pre-heading Find data and code you can use
-          %label Search over #{pluralize(Scraper.count, "scraper")}
-        .input-group.col-sm-12.col-md-9.col-lg-8
-          = hidden_field_tag :type, @type
-          %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
-          .input-group-btn
-            %button.btn.btn-primary{type: "submit"} Search
-        %p.search-suggestions
-          Try #{link_to "parliament", search_path(q: "parliament")},
-          #{ link_to "planning", search_path(q: "planning")} or
-          #{ link_to "Ghana", search_path(q: "Ghana")}
+= render partial: "search_banner"
 
 .container
   .row

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -10,7 +10,7 @@
           .input-group-btn
             %button.btn.btn-primary{type: "submit"} Search
         %p.search-suggestions
-          try #{link_to "parliament", search_path(q: "parliament")},
+          Try #{link_to "parliament", search_path(q: "parliament")},
           #{ link_to "planning", search_path(q: "planning")} or
           #{ link_to "Ghana", search_path(q: "Ghana")}
 

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -6,7 +6,7 @@
           %label Search over 2000 scrapers
         .input-group.col-sm-12.col-md-8.col-lg-7
           = hidden_field_tag :type, @type
-          %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+          %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
           .input-group-btn
             %button.btn.btn-primary{type: "submit"} Search
         %p.search-suggestions

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -3,7 +3,7 @@
     .search-header
       =form_tag search_path, method: "get", class: "form-inline" do
         %h1.label-heading
-          %label Search over 2000 scrapers
+          %label Search over #{pluralize(Scraper.count, "scraper")}
         .input-group.col-sm-12.col-md-9.col-lg-8
           = hidden_field_tag :type, @type
           %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -4,7 +4,7 @@
       =form_tag search_path, method: "get", class: "form-inline" do
         %h1.label-heading
           %label Search over 2000 scrapers
-        .input-group.col-sm-12.col-md-8.col-lg-7
+        .input-group.col-sm-12.col-md-9.col-lg-8
           = hidden_field_tag :type, @type
           %input.form-control#query{required: "required", type: "search", maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
           .input-group-btn

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -9,7 +9,7 @@
           %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
           .input-group-btn
             %button.btn.btn-primary{type: "submit"} Search
-        %p
+        %p.search-suggestions
           try #{link_to "parliament", search_path(q: "parliament")},
           #{ link_to "planning", search_path(q: "planning")} or
           #{ link_to "Ghana", search_path(q: "Ghana")}

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -1,4 +1,6 @@
-= render partial: "search_banner"
+.banner-search.banner
+  .container
+    = render partial: "search_banner"
 
 .container
   .row

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -8,6 +8,10 @@
         %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
         .input-group-btn
           %button.btn.btn-primary{type: "submit"} Search
+      %p
+        try #{link_to "parliament", search_path(q: "parliament")},
+        #{ link_to "planning", search_path(q: "planning")} or
+        #{ link_to "Ghana", search_path(q: "Ghana")}
 
 .container
   .row

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -3,6 +3,7 @@
     .search-header
       =form_tag search_path, method: "get", class: "form-inline" do
         %h1.label-heading
+          %small.pre-heading Find data and code you can use
           %label Search over #{pluralize(Scraper.count, "scraper")}
         .input-group.col-sm-12.col-md-9.col-lg-8
           = hidden_field_tag :type, @type

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -1,4 +1,15 @@
 .container
+  .search-header
+    =form_tag search_path, method: "get", class: "form-inline" do
+      %h1.label-heading
+        %label Search
+      .input-group.col-sm-12.col-md-8.col-lg-7
+        = hidden_field_tag :type, @type
+        %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/
+        .input-group-btn
+          %button.btn.btn-primary{type: "submit"} Search
+
+.container
   .row
     .col-md-6
       %h2 Recent New Users

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -2,7 +2,7 @@
   .search-header
     =form_tag search_path, method: "get", class: "form-inline" do
       %h1.label-heading
-        %label Search
+        %label Search over 2000 scrapers
       .input-group.col-sm-12.col-md-8.col-lg-7
         = hidden_field_tag :type, @type
         %input.form-control#query{required: "required", type: "search", autofocus: (@q.blank? ? true : false), maxlength: "256", name: "q", value: "#{@q if !@q.blank?}"}/


### PR DESCRIPTION
To help citizens explore morph and discover scrapers of interest to them, these commits add a simple search form banner sections to the logged in landing page:

![screen shot 2015-05-06 at 9 15 54 am](https://cloud.githubusercontent.com/assets/1239550/7485131/bb033134-f3d4-11e4-93a3-ca32e4db65d8.png)
![screen shot 2015-05-06 at 9 15 48 am](https://cloud.githubusercontent.com/assets/1239550/7485134/c18597ea-f3d4-11e4-8bd5-e444e339b308.png)

* [x] Before this is merged we need to settle on the suggested search terms (see [discussion on #701](https://github.com/openaustralia/morph/issues/701#issuecomment-99253000)).

relates to #698 

closes #701 