### PR TITLE
[For review] First pass of 'Create first scraper'

### DIFF
--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -46,6 +46,14 @@
   }
 }
 
+.banner-add-scraper {
+  padding-bottom: 24px;
+
+  @media (min-width: $screen-md-min) {
+    padding-bottom: 48px;
+  }
+}
+
 .banner-wrapper {
   background-color: #716b58;
 }

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -52,6 +52,10 @@
   @media (min-width: $screen-md-min) {
     padding-bottom: 48px;
   }
+
+  h2 {
+    font-weight: normal;
+  }
 }
 
 .banner-wrapper {

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -54,7 +54,12 @@
   }
 
   h2 {
-    font-weight: normal;
+    font-size: $font-size-h4;
+
+    @media (min-width: $screen-sm-min) {
+      font-size: $font-size-h3;
+      font-weight: normal;
+    }
   }
 }
 

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -5,6 +5,12 @@
       Search over #{pluralize(floor_to_hundreds(Scraper.count), "scraper")}
     = render partial: "search_form"
 
+- if current_user.scrapers.empty?
+  .banner
+    .container
+      %h2 Unlock the data you need
+      = link_to "Create your first scraper", new_scraper_path, class: "btn btn-primary btn-lg"
+
 .container
   .row
     .col-md-6

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -6,7 +6,7 @@
     = render partial: "search_form"
 
 - if current_user.scrapers.empty?
-  .banner
+  .banner-add-scraper.banner
     .container
       %h2 Unlock the data you need
       = link_to "Create your first scraper", new_scraper_path, class: "btn btn-primary btn-lg"

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -8,7 +8,7 @@
 - if current_user.scrapers.empty?
   .banner-add-scraper.banner
     .container
-      %h2 Unlock the data you need
+      %h2.h3 Unlock the data you need
       = link_to "Create your first scraper", new_scraper_path, class: "btn btn-primary btn-lg"
 
 .container

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -8,7 +8,7 @@
 - if current_user.scrapers.empty?
   .banner-add-scraper.banner
     .container
-      %h2.h3 Unlock the data you need
+      %h2 Unlock the data you need
       = link_to "Create your first scraper", new_scraper_path, class: "btn btn-primary btn-lg"
 
 .container


### PR DESCRIPTION
*As a new user, when I visit the landing page, I want some help to write my first scraper on morph.io, so that I can get the data I need.*

This is the minimal first pass at helping these people out. It adds a heading and button to the logged in landing page for users who have no scrapers:

![screen shot 2015-05-06 at 5 58 15 pm](https://cloud.githubusercontent.com/assets/1239550/7489511/ec7b1a92-f41a-11e4-8455-d87664dbe6b1.png)

There's discussion about potential layout options [on #707](https://github.com/openaustralia/morph/issues/707#issuecomment-99357086).

I'm not sure whether block should go up on the righthand side or not, so I've pushed this hear to discuss.