### PR TITLE
[WIP] Notice and documentation that downloads are public

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -127,16 +127,23 @@
 }
 
 .scraper-download-block {
-  .btn-group a:last-child {
-    @media (min-width: $screen-md-min) {
-      margin-right: .5em;
+  margin-top: 1em;
+
+  .btn-group {
+    margin-bottom: 1em;
+
+    a:last-child {
+      @media (min-width: $screen-md-min) {
+        margin-right: .5em;
+      }
     }
   }
 }
 
 .download-privacy-notice {
-  margin-top: 1em;
+  margin: 0 0 1em;
   display: inline-block;
+  vertical-align: top;
 
   &.alert {
     padding: 0.25em .5em;

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -126,6 +126,14 @@
   }
 }
 
+.scraper-download-block {
+  .btn-group a:last-child {
+    @media (min-width: $screen-md-min) {
+      margin-right: .5em;
+    }
+  }
+}
+
 .download-privacy-notice {
   margin-top: 1em;
   display: inline-block;

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -127,6 +127,7 @@
 }
 
 .download-privacy-notice {
+  margin-top: 1em;
   display: inline-block;
 }
 

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -126,6 +126,10 @@
   }
 }
 
+.download-privacy-notice {
+  display: inline-block;
+}
+
 .popover-content {
   word-wrap: break-word;
 }

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -137,6 +137,10 @@
 .download-privacy-notice {
   margin-top: 1em;
   display: inline-block;
+
+  &.alert {
+    padding: 0.25em .5em;
+  }
 }
 
 .popover-content {

--- a/app/views/documentation/_open_downloads.md
+++ b/app/views/documentation/_open_downloads.md
@@ -1,7 +1,7 @@
 On each scraper you can see who has downloaded or used the API to get the data.
 Your downloads are also listed there.
 
-By being able to see openly who is using what we aim to promote collaboration and serendipity.
+By being able to see openly who is using what, we aim to promote collaboration and serendipity.
 Creating or scraping data is important, but it's people using it that really makes it exciting. Showing who downloads what, connects people making scrapers with those who use the data.
 
 There may be situations where you don't want to be identified as downloading some data. In that case please create an alternate GitHub (and morph.io) account which does not identify you and use that to download the data.

--- a/app/views/documentation/_open_downloads.md
+++ b/app/views/documentation/_open_downloads.md
@@ -1,0 +1,21 @@
+You can see the list of people who have downloaded the data
+collected by a scraper on morph.io.
+Your downloads will be listed.
+Use this information to find new people to collaborate with
+and more open data to use in your own projects.
+
+Downloads of .csv and database files, as well as calls to
+scraper APIs are counted as ‘Downloads’.
+
+If it is important for you to protect your identity
+in downloading data from morph.io, you have a couple of options.
+You could make an alternate Github account and email
+for your work on morph.io, that cannot be linked back to the
+identity you would like to protect.
+
+If this is not possible, please contact us.
+We'll do our best to help if you explain you're circumstances.
+Morph is the scraping platform for civic hackers,
+activists and researchers. We strongly believe in being open
+by default, but understand there are times when data collection
+must be protected.

--- a/app/views/documentation/_open_downloads.md
+++ b/app/views/documentation/_open_downloads.md
@@ -1,21 +1,9 @@
-You can see the list of people who have downloaded the data
-collected by a scraper on morph.io.
-Your downloads will be listed.
-Use this information to find new people to collaborate with
-and more open data to use in your own projects.
+On each scraper you can see who has downloaded or used the API to get the data.
+Your downloads are also listed there.
 
-Downloads of .csv and database files, as well as calls to
-scraper APIs are counted as ‘Downloads’.
+By being able to see openly who is using what we aim to promote collaboration and serendipity.
+Creating or scraping data is important, but it's people using it that really makes it exciting. Showing who downloads what, connects people making scrapers with those who use the data.
 
-If it is important for you to protect your identity
-in downloading data from morph.io, you have a couple of options.
-You could make an alternate Github account and email
-for your work on morph.io, that cannot be linked back to the
-identity you would like to protect.
+There may be situations where you don't want to be identified as downloading some data. In that case please create an alternate GitHub (and morph.io) account which does not identify you and use that to download the data.
 
-If this is not possible, please contact us.
-We'll do our best to help if you explain you're circumstances.
-Morph is the scraping platform for civic hackers,
-activists and researchers. We strongly believe in being open
-by default, but understand there are times when data collection
-must be protected.
+If that's not possible, or you have any questions, please [contact us](mailto:contact@oaf.org.au).

--- a/app/views/documentation/api.html.haml
+++ b/app/views/documentation/api.html.haml
@@ -8,6 +8,10 @@
   %code
     GET #{api_url_in_html(content_tag(:em, "[scraper]"), content_tag(:em, "[format]"), content_tag(:em, "[api_key]"), content_tag(:em, "[sql]"), "")}
 
+%p
+  Your API calls will be shown as downloads on the scraper page.
+  = link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'
+
 %h2 Parameters
 
 -# TODO Write this whole form in a more concise way using the magic of simple_form

--- a/app/views/documentation/api.html.haml
+++ b/app/views/documentation/api.html.haml
@@ -8,7 +8,7 @@
   %code
     GET #{api_url_in_html(content_tag(:em, "[scraper]"), content_tag(:em, "[format]"), content_tag(:em, "[api_key]"), content_tag(:em, "[sql]"), "")}
 
-%p
+%p.alert.alert-info
   Your API calls will be shown as downloads on the scraper page.
   = link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'
 

--- a/app/views/documentation/index.html.haml
+++ b/app/views/documentation/index.html.haml
@@ -50,6 +50,14 @@
 
 .row
   .col-sm-9
+    %h3.section#open_downloads See who is using the data
+    :markdown
+      #{render "open_downloads.md"}
+  .col-sm-3
+    = improve_button "Improve this section", "_open_downloads.md"
+
+.row
+  .col-sm-9
     %h3.section#responsibility Your responsibility
     :markdown
       #{render "responsibility.md"}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -25,7 +25,7 @@
         - scraper.database.table_names.each do |table|
           .tab-pane{class: ("active" if table == active_table), id: "table_#{table}"}
             - rows = scraper.database.first_ten_rows(table)
-            %p.scraper-download-block
+            .scraper-download-block
               - unless signed_in?
                 To download data
                 = button_link_to "sign in with GitHub", user_omniauth_authorize_path(:github)

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,9 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                %span.download-privacy-notice Your downloads will be shown above #{link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'}
+                %span.download-privacy-notice
+                  Your downloads will be shown above
+                  = link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -27,8 +27,9 @@
             - rows = scraper.database.first_ten_rows(table)
             .scraper-download-block
               - unless signed_in?
-                To download data
-                = button_link_to "sign in with GitHub", user_omniauth_authorize_path(:github)
+                %p
+                  To download data
+                  = button_link_to "sign in with GitHub", user_omniauth_authorize_path(:github)
               .btn-group
                 = button_link_to "Download table (as CSV)", data_scraper_path(scraper, format: :csv, query: scraper.database.select_all(table), key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,7 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                %span.download-privacy-notice
+                %span.download-privacy-notice.alert.alert-info
                   Your downloads will be shown above
                   = link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,7 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                %small Downloaders will be listed above
+                %small.download-privacy-notice Downloaders will be listed above
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -33,8 +33,8 @@
                 = button_link_to "Download table (as CSV)", data_scraper_path(scraper, format: :csv, query: scraper.database.select_all(table), key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
-            - if user_signed_in?
-              %p Downloaders will be listed above
+              - if user_signed_in?
+                Downloaders will be listed above
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -25,7 +25,7 @@
         - scraper.database.table_names.each do |table|
           .tab-pane{class: ("active" if table == active_table), id: "table_#{table}"}
             - rows = scraper.database.first_ten_rows(table)
-            %p
+            %p.scraper-download-block
               - unless signed_in?
                 To download data
                 = button_link_to "sign in with GitHub", user_omniauth_authorize_path(:github)

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,7 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                Downloaders will be listed above
+                %small Downloaders will be listed above
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -33,6 +33,8 @@
                 = button_link_to "Download table (as CSV)", data_scraper_path(scraper, format: :csv, query: scraper.database.select_all(table), key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
+            - if user_signed_in?
+              %p Downloaders will be listed above
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,7 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                %span.download-privacy-notice Your downloads will be shown above
+                %span.download-privacy-notice Your downloads will be shown above #{link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'}
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,7 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                %small.download-privacy-notice Downloaders will be listed above
+                %small.download-privacy-notice Your downloads will be shown above
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -34,7 +34,7 @@
                 = button_link_to "Download SQLite database (#{number_to_human_size scraper.database.sqlite_db_size})", data_scraper_path(scraper, :format => :sqlite, key: (current_user.api_key if current_user)), disabled: !signed_in?
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
-                %small.download-privacy-notice Your downloads will be shown above
+                %span.download-privacy-notice Your downloads will be shown above
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame
               %table.table.table-striped.table-bordered.table-condensed.tablesaw.tablesaw-stack.scroller-panel{data: {tablesaw: {mode: "stack" }}}


### PR DESCRIPTION
We want to give users some notice and explain why we're showing their data download activity.

This PR adds a small notice to the scraper page (next to the download links) and API docs page. It also adds a new section to the documentation about this feature.

I think think notices could be in an into alert style of some kind, gonna try that. Feed back on that and on the text would be much appreciated.

Here's the text file https://github.com/openaustralia/morph/blob/downloader-notice/app/views/documentation/_open_downloads.md