### PR TITLE
Fix download alert notice visual bugs

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -138,17 +138,20 @@
       }
     }
   }
+
+
+  .download-privacy-notice {
+    margin: 0 0 1em;
+    display: inline-block;
+    vertical-align: top;
+
+    &.alert {
+      padding: 0.25em .5em;
+    }
+  }
 }
 
 .download-privacy-notice {
-  margin: 0 0 1em;
-  display: inline-block;
-  vertical-align: top;
-
-  &.alert {
-    padding: 0.25em .5em;
-  }
-
   a {
     text-decoration: underline;
   }

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -148,6 +148,10 @@
   &.alert {
     padding: 0.25em .5em;
   }
+
+  a {
+    text-decoration: underline;
+  }
 }
 
 .popover-content {

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -143,7 +143,7 @@
   .download-privacy-notice {
     margin: 0 0 1em;
     display: inline-block;
-    vertical-align: top;
+    vertical-align: middle;
 
     &.alert {
       padding: 0.25em .5em;

--- a/app/views/documentation/api.html.haml
+++ b/app/views/documentation/api.html.haml
@@ -8,7 +8,7 @@
   %code
     GET #{api_url_in_html(content_tag(:em, "[scraper]"), content_tag(:em, "[format]"), content_tag(:em, "[api_key]"), content_tag(:em, "[sql]"), "")}
 
-%p.alert.alert-info
+%p.alert.alert-info.download-privacy-notice
   Your API calls will be shown as downloads on the scraper page.
   = link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'
 

--- a/app/views/scrapers/_data.html.haml
+++ b/app/views/scrapers/_data.html.haml
@@ -35,7 +35,7 @@
                 = button_link_to "Use the API", api_documentation_index_path(scraper: scraper.full_name)
               - if user_signed_in?
                 %span.download-privacy-notice.alert.alert-info
-                  Your downloads will be shown above
+                  Your downloads will be shown above.
                   = link_to "Why?", documentation_index_path(anchor: "open_downloads"), title: 'Read about why downloader information is public and open.'
             %p rows #{[10, scraper.database.no_rows(table)].min} / #{scraper.database.no_rows(table)}
             .table-responsive.scraper-data.scroller-frame


### PR DESCRIPTION
This makes the link more distinct by adding a stop before it (as suggested by @henare :+1: ) and also giving it an underline. This applies the underline style to the alert on the API page for consistency.

closes #714 

It also aligns the notice next to the download button group to the middle vertically so it's still smaller but feels more even.

closes #713 

Before:
![screen shot 2015-05-11 at 5 25 25 pm](https://cloud.githubusercontent.com/assets/1239550/7560137/4f1e25ae-f803-11e4-9587-ccb0601aaf84.png)

After:
![screen shot 2015-05-11 at 5 25 03 pm](https://cloud.githubusercontent.com/assets/1239550/7560135/42c58c20-f803-11e4-9b0d-055c637b77c1.png)

