### PR TITLE
Stop scraper headings getting clipped at the bottom

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -321,6 +321,7 @@ a i.fa-clock-o {
 }
 
 h1.full_name {
+  padding-bottom: 1.2; // compensate for overflow:hidden, keep descenders visible
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
Scraper headings are getting clipped at the bottom because we use overflow: hidden; to stop really long scraper headings breaking the layout.

![screen shot 2015-05-13 at 6 18 14 pm](https://cloud.githubusercontent.com/assets/1239550/7606481/7b000116-f99c-11e4-9dff-335350d96036.png)

This adds a touch of padding to the bottom of h1's so their is space for the descenders of letters.

The other way to fix it is by increasing the line-height slightly, but that has a bigger visual impact in more situations, so I think the padding is a better approach. Even better would have been if `overflow-y:visible` worked, but it doesn't :( according to [MDN, still an experimental feature](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y).