### PR TITLE
Fix heading cutoff bug

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -337,6 +337,7 @@ a i.fa-clock-o {
 }
 
 h1.full_name {
+  padding-bottom: 2px; // compensate for overflow:hidden, keep descenders visible
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -337,7 +337,6 @@ a i.fa-clock-o {
 }
 
 h1.full_name {
-  padding-bottom: 1.2; // compensate for overflow:hidden, keep descenders visible
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
This fixes the heading clipping issue https://github.com/openaustralia/morph/issues/594 which was meant to be fixed by https://github.com/openaustralia/morph/pull/729 .

1. revert the commit that didn't work because it's `padding-bottom` value was invalod
2. Reimplement the fix with the correct value.
