### PR TITLE
Summarise scraper for scraper show page meta description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'sitemap_generator'
 gem 'kaminari'
 gem 'kaminari-bootstrap', '~> 3.0.1'
 gem "rails-timeago", "~> 2.0"
+gem 'meta-tags'
 # Rails 4 compatibility isn't released yet. So tracking HEAD.
 gem 'activeadmin', github: 'activeadmin'
 gem 'faye'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,8 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    meta-tags (2.0.0)
+      actionpack (>= 3.0.0)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
@@ -503,6 +505,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   kaminari-bootstrap (~> 3.0.1)
+  meta-tags
   multiblock
   mysql2
   newrelic_rpm

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -28,6 +28,10 @@ module RunsHelper
     end
   end
 
+  def scraped_domain_link(d)
+    link_to h(d.name), h("http://#{d.name}"), target: "_blank"
+  end
+
   def scraped_domains_list_without_links(scraped_domains)
     d = scraped_domains.map{|d| h(d.name)}
     # If there are more than 3 in the list then summarise

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -28,8 +28,8 @@ module RunsHelper
     end
   end
 
-  def scraped_domain_link(d)
-    link_to h(d.name), h("http://#{d.name}"), target: "_blank"
+  def scraped_domain_link(domain)
+    link_to h(domain.name), h("http://#{domain.name}"), target: "_blank"
   end
 
   def scraped_domains_list_without_links(scraped_domains)

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -32,6 +32,12 @@ module RunsHelper
     link_to h(domain.name), h("http://#{domain.name}"), target: "_blank"
   end
 
+  def scraped_domains_list2(scraped_domains, with_links = true)
+    d = scraped_domains.map{|d| (with_links ? scraped_domain_link(d) : h(d.name))}
+    # If there are more than 3 in the list then summarise
+    summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
+  end
+
   def scraped_domains_list_without_links(scraped_domains)
     d = scraped_domains.map{|d| h(d.name)}
     # If there are more than 3 in the list then summarise

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -39,7 +39,7 @@ module RunsHelper
   end
 
   def scraped_domains_list(scraped_domains)
-    d = scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}"), target: "_blank"}
+    d = scraped_domains.map{|d| scraped_domain_link(d)}
     # If there are more than 3 in the list then summarise
     summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
   end

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -28,6 +28,12 @@ module RunsHelper
     end
   end
 
+  def scraped_domains_list_without_links(scraped_domains)
+    d = scraped_domains.map{|d| h(d.name)}
+    # If there are more than 3 in the list then summarise
+    summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
+  end
+
   def scraped_domains_list(scraped_domains)
     d = scraped_domains.map{|d| link_to h(d.name), h("http://#{d.name}"), target: "_blank"}
     # If there are more than 3 in the list then summarise

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -32,20 +32,8 @@ module RunsHelper
     link_to h(domain.name), h("http://#{domain.name}"), target: "_blank"
   end
 
-  def scraped_domains_list2(scraped_domains, with_links = true)
+  def scraped_domains_list(scraped_domains, with_links = true)
     d = scraped_domains.map{|d| (with_links ? scraped_domain_link(d) : h(d.name))}
-    # If there are more than 3 in the list then summarise
-    summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
-  end
-
-  def scraped_domains_list_without_links(scraped_domains)
-    d = scraped_domains.map{|d| h(d.name)}
-    # If there are more than 3 in the list then summarise
-    summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
-  end
-
-  def scraped_domains_list(scraped_domains)
-    d = scraped_domains.map{|d| scraped_domain_link(d)}
     # If there are more than 3 in the list then summarise
     summary_of_array(d, "other domain".html_safe).to_sentence.html_safe
   end

--- a/app/helpers/scrapers_helper.rb
+++ b/app/helpers/scrapers_helper.rb
@@ -44,7 +44,11 @@ module ScrapersHelper
     if !scraper.description.blank?
       scraper.description
     else
-      'A scraper to collect structured data from the web.'
+      if !scraper.scraped_domains.empty?
+        "A scraper to collect structured data from #{scraped_domains_list_without_links(scraper.scraped_domains)}."
+      else
+        'A scraper to collect structured data from the web.'
+      end
     end
   end
 end

--- a/app/helpers/scrapers_helper.rb
+++ b/app/helpers/scrapers_helper.rb
@@ -44,10 +44,11 @@ module ScrapersHelper
     if !scraper.description.blank?
       scraper.description
     else
+      text = 'A scraper to collect structured data from '
       if !scraper.scraped_domains.empty?
-        "A scraper to collect structured data from #{scraped_domains_list(scraper.scraped_domains, false)}."
+        text += "#{scraped_domains_list(scraper.scraped_domains, false)}."
       else
-        'A scraper to collect structured data from the web.'
+        text += 'the web.'
       end
     end
   end

--- a/app/helpers/scrapers_helper.rb
+++ b/app/helpers/scrapers_helper.rb
@@ -39,4 +39,12 @@ module ScrapersHelper
   def link_url_or_escape(text)
     is_url?(text) ? auto_link_fallback(text) : escape_once(text)
   end
+
+  def scraper_description(scraper)
+    if !scraper.description.blank?
+      scraper.description
+    else
+      'A scraper to collect structured data from the web.'
+    end
+  end
 end

--- a/app/helpers/scrapers_helper.rb
+++ b/app/helpers/scrapers_helper.rb
@@ -45,7 +45,7 @@ module ScrapersHelper
       scraper.description
     else
       if !scraper.scraped_domains.empty?
-        "A scraper to collect structured data from #{scraped_domains_list_without_links(scraper.scraped_domains)}."
+        "A scraper to collect structured data from #{scraped_domains_list(scraper.scraped_domains, false)}."
       else
         'A scraper to collect structured data from the web.'
       end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,7 @@
     %meta(charset="utf-8")
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1")
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
-    %meta(content='Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.' name='Description')
+    = display_meta_tags
     %title= content_for?(:title) ? "morph.io: #{yield(:title)}" : "morph.io"
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements

--- a/app/views/scrapers/_show_normal.html.haml
+++ b/app/views/scrapers/_show_normal.html.haml
@@ -16,7 +16,7 @@
     - unless scraper.scraped_domains.empty?
       %p
         Scrapes
-        = scraped_domains_list(scraper.scraped_domains)
+        = scraped_domains_list(scraper.scraped_domains, true)
       -# Only shows the meta info from the first domain
       -# TODO Figure out what to do with more than one domain
       - if scraper.scraped_domains.first.meta_or_title.present?

--- a/app/views/scrapers/show.html.haml
+++ b/app/views/scrapers/show.html.haml
@@ -1,4 +1,5 @@
 - content_for :title, @scraper.full_name
+- set_meta_tags description: (!@scraper.description.blank? ? @scraper.description : 'A scraper to collect structured data from the web')
 
 .container
   = sync partial: "show_partial", resource: @scraper, refetch: true

--- a/app/views/scrapers/show.html.haml
+++ b/app/views/scrapers/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :title, @scraper.full_name
-- set_meta_tags description: (!@scraper.description.blank? ? @scraper.description : 'A scraper to collect structured data from the web')
+- set_meta_tags description: scraper_description(@scraper)
 
 .container
   = sync partial: "show_partial", resource: @scraper, refetch: true

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -1,3 +1,5 @@
+- set_meta_tags description: 'Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.'
+
 .banner-wrapper
   .banner.container#banner
     %h2 Take the hassle out of web&nbsp;scraping

--- a/app/views/static/_signed_out_index.html.haml
+++ b/app/views/static/_signed_out_index.html.haml
@@ -1,5 +1,3 @@
-- set_meta_tags description: 'Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.'
-
 .banner-wrapper
   .banner.container#banner
     %h2 Take the hassle out of web&nbsp;scraping

--- a/app/views/static/index.html.haml
+++ b/app/views/static/index.html.haml
@@ -1,3 +1,5 @@
+- set_meta_tags description: 'Get structured data out of the web. Code collaboration through GitHub. Run your scrapers in the cloud.'
+
 - if signed_in?
   = render "signed_in_index"
 - else

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -35,6 +35,62 @@ describe RunsHelper do
       end
     end
 
+    describe "#scraped_domains_list2" do
+      describe "#scraped_domains_list2 with links" do
+        it do
+          expect(helper.scraped_domains_list2([foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
+          expect(helper.scraped_domains_list2([foo_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a> and <a href="http://bar.com" target="_blank">bar.com</a>'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, and <a href="http://www.foo.com" target="_blank">www.foo.com</a>'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 1 other domain'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 2 other domains'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], true)).to be_html_safe
+        end
+      end
+
+      describe "#scraped_domains_list2 without links" do
+        it do
+          expect(helper.scraped_domains_list2([foo_domain], false)).to eq 'foo.com'
+          expect(helper.scraped_domains_list2([foo_domain], false)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain], false)).to eq 'foo.com and bar.com'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain], false)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], false)).to eq 'foo.com, bar.com, and www.foo.com'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], false)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], false)).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], false)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], false)).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
+          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], false)).to be_html_safe
+        end
+      end
+    end
+
     describe "#scraped_domains_list" do
       it do
         expect(helper.scraped_domains_list([foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -1,6 +1,39 @@
 require 'spec_helper'
 
 describe RunsHelper do
+  describe "#scraped_domains_list_without_links" do
+    let(:foo_domain) { mock_model(Domain, name: "foo.com")}
+    let(:bar_domain) { mock_model(Domain, name: "bar.com")}
+    let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
+    let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com")}
+    let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
+
+    it do
+      expect(helper.scraped_domains_list_without_links([foo_domain])).to eq 'foo.com'
+      expect(helper.scraped_domains_list_without_links([foo_domain])).to be_html_safe
+    end
+
+    it do
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to eq 'foo.com and bar.com'
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to be_html_safe
+    end
+
+    it do
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, and www.foo.com'
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
+    end
+
+    it do
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
+    end
+
+    it do
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
+      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
+    end
+  end
+
   describe "#scraped_domains_list" do
     let(:foo_domain) { mock_model(Domain, name: "foo.com")}
     let(:bar_domain) { mock_model(Domain, name: "bar.com")}

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -1,97 +1,87 @@
 require 'spec_helper'
 
 describe RunsHelper do
-  describe "#scraped_domains_list_without_links" do
+  context "There are scraped domains" do
     let(:foo_domain) { mock_model(Domain, name: "foo.com")}
     let(:bar_domain) { mock_model(Domain, name: "bar.com")}
     let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
     let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com")}
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
 
-    it do
-      expect(helper.scraped_domains_list_without_links([foo_domain])).to eq 'foo.com'
-      expect(helper.scraped_domains_list_without_links([foo_domain])).to be_html_safe
+    describe "#scraped_domains_list_without_links" do
+      it do
+        expect(helper.scraped_domains_list_without_links([foo_domain])).to eq 'foo.com'
+        expect(helper.scraped_domains_list_without_links([foo_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to eq 'foo.com and bar.com'
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, and www.foo.com'
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
+        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
+      end
     end
 
-    it do
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to eq 'foo.com and bar.com'
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to be_html_safe
+    describe "#scraped_domains_list" do
+      it do
+        expect(helper.scraped_domains_list([foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
+        expect(helper.scraped_domains_list([foo_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list([foo_domain, bar_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a> and <a href="http://bar.com" target="_blank">bar.com</a>'
+        expect(helper.scraped_domains_list([foo_domain, bar_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, and <a href="http://www.foo.com" target="_blank">www.foo.com</a>'
+        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 1 other domain'
+        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
+      end
+
+      it do
+        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 2 other domains'
+        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
+      end
     end
 
-    it do
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, and www.foo.com'
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
-    end
+    describe "#simplified_scraped_domains_list" do
+      it do
+        expect(helper.simplified_scraped_domains_list([foo_domain])).to eq 'foo.com'
+      end
 
-    it do
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
-    end
+      it do
+        expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain])).to eq 'foo.com, bar.com'
+      end
 
-    it do
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
-      expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
-    end
-  end
+      it do
+        expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, www.foo.com'
+      end
 
-  describe "#scraped_domains_list" do
-    let(:foo_domain) { mock_model(Domain, name: "foo.com")}
-    let(:bar_domain) { mock_model(Domain, name: "bar.com")}
-    let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
-    let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com")}
-    let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
+      it do
+        expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other'
+      end
 
-    it do
-      expect(helper.scraped_domains_list([foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
-      expect(helper.scraped_domains_list([foo_domain])).to be_html_safe
-    end
-
-    it do
-      expect(helper.scraped_domains_list([foo_domain, bar_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a> and <a href="http://bar.com" target="_blank">bar.com</a>'
-      expect(helper.scraped_domains_list([foo_domain, bar_domain])).to be_html_safe
-    end
-
-    it do
-      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, and <a href="http://www.foo.com" target="_blank">www.foo.com</a>'
-      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
-    end
-
-    it do
-      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 1 other domain'
-      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
-    end
-
-    it do
-      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 2 other domains'
-      expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
-    end
-  end
-
-  describe "#simplified_scraped_domains_list" do
-    let(:foo_domain) { mock_model(Domain, name: "foo.com")}
-    let(:bar_domain) { mock_model(Domain, name: "bar.com")}
-    let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com")}
-    let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com")}
-    let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
-
-    it do
-      expect(helper.simplified_scraped_domains_list([foo_domain])).to eq 'foo.com'
-    end
-
-    it do
-      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain])).to eq 'foo.com, bar.com'
-    end
-
-    it do
-      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, www.foo.com'
-    end
-
-    it do
-      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other'
-    end
-
-    it do
-      expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 others'
+      it do
+        expect(helper.simplified_scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 others'
+      end
     end
   end
 end

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -8,113 +8,59 @@ describe RunsHelper do
     let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com")}
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
 
-    describe "#scraped_domains_list_without_links" do
-      it do
-        expect(helper.scraped_domains_list_without_links([foo_domain])).to eq 'foo.com'
-        expect(helper.scraped_domains_list_without_links([foo_domain])).to be_html_safe
-      end
-
-      it do
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to eq 'foo.com and bar.com'
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain])).to be_html_safe
-      end
-
-      it do
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to eq 'foo.com, bar.com, and www.foo.com'
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
-      end
-
-      it do
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
-      end
-
-      it do
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
-        expect(helper.scraped_domains_list_without_links([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
-      end
-    end
-
-    describe "#scraped_domains_list2" do
-      describe "#scraped_domains_list2 with links" do
-        it do
-          expect(helper.scraped_domains_list2([foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
-          expect(helper.scraped_domains_list2([foo_domain], true)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a> and <a href="http://bar.com" target="_blank">bar.com</a>'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain], true)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, and <a href="http://www.foo.com" target="_blank">www.foo.com</a>'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], true)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 1 other domain'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], true)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 2 other domains'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], true)).to be_html_safe
-        end
-      end
-
-      describe "#scraped_domains_list2 without links" do
-        it do
-          expect(helper.scraped_domains_list2([foo_domain], false)).to eq 'foo.com'
-          expect(helper.scraped_domains_list2([foo_domain], false)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain], false)).to eq 'foo.com and bar.com'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain], false)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], false)).to eq 'foo.com, bar.com, and www.foo.com'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain], false)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], false)).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain], false)).to be_html_safe
-        end
-
-        it do
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], false)).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
-          expect(helper.scraped_domains_list2([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], false)).to be_html_safe
-        end
-      end
-    end
-
     describe "#scraped_domains_list" do
-      it do
-        expect(helper.scraped_domains_list([foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
-        expect(helper.scraped_domains_list([foo_domain])).to be_html_safe
+      describe "#scraped_domains_list with links" do
+        it do
+          expect(helper.scraped_domains_list([foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
+          expect(helper.scraped_domains_list([foo_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a> and <a href="http://bar.com" target="_blank">bar.com</a>'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, and <a href="http://www.foo.com" target="_blank">www.foo.com</a>'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 1 other domain'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain], true)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 2 other domains'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], true)).to be_html_safe
+        end
       end
 
-      it do
-        expect(helper.scraped_domains_list([foo_domain, bar_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a> and <a href="http://bar.com" target="_blank">bar.com</a>'
-        expect(helper.scraped_domains_list([foo_domain, bar_domain])).to be_html_safe
-      end
+      describe "#scraped_domains_list without links" do
+        it do
+          expect(helper.scraped_domains_list([foo_domain], false)).to eq 'foo.com'
+          expect(helper.scraped_domains_list([foo_domain], false)).to be_html_safe
+        end
 
-      it do
-        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, and <a href="http://www.foo.com" target="_blank">www.foo.com</a>'
-        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain])).to be_html_safe
-      end
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain], false)).to eq 'foo.com and bar.com'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain], false)).to be_html_safe
+        end
 
-      it do
-        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 1 other domain'
-        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain])).to be_html_safe
-      end
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain], false)).to eq 'foo.com, bar.com, and www.foo.com'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain], false)).to be_html_safe
+        end
 
-      it do
-        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to eq '<a href="http://foo.com" target="_blank">foo.com</a>, <a href="http://bar.com" target="_blank">bar.com</a>, <a href="http://www.foo.com" target="_blank">www.foo.com</a>, and 2 other domains'
-        expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])).to be_html_safe
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain], false)).to eq 'foo.com, bar.com, www.foo.com, and 1 other domain'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain], false)).to be_html_safe
+        end
+
+        it do
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], false)).to eq 'foo.com, bar.com, www.foo.com, and 2 other domains'
+          expect(helper.scraped_domains_list([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain], false)).to be_html_safe
+        end
       end
     end
 

--- a/spec/helpers/runs_helper_spec.rb
+++ b/spec/helpers/runs_helper_spec.rb
@@ -9,7 +9,7 @@ describe RunsHelper do
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com")}
 
     describe "#scraped_domains_list" do
-      describe "#scraped_domains_list with links" do
+      describe "#with links" do
         it do
           expect(helper.scraped_domains_list([foo_domain], true)).to eq '<a href="http://foo.com" target="_blank">foo.com</a>'
           expect(helper.scraped_domains_list([foo_domain], true)).to be_html_safe
@@ -36,7 +36,7 @@ describe RunsHelper do
         end
       end
 
-      describe "#scraped_domains_list without links" do
+      describe "#without links" do
         it do
           expect(helper.scraped_domains_list([foo_domain], false)).to eq 'foo.com'
           expect(helper.scraped_domains_list([foo_domain], false)).to be_html_safe

--- a/spec/helpers/scrapers_helper_spec.rb
+++ b/spec/helpers/scrapers_helper_spec.rb
@@ -9,4 +9,20 @@ describe ScrapersHelper do
     it { expect(helper.is_url?("http://example.com")).to eq true }
     it { expect(helper.is_url?("http://example.com/#anchor")).to eq true }
   end
+
+  describe "#scraper_description" do
+    let(:scraper) { Scraper.new }
+
+    context "scraper description is blank" do
+      it { expect(helper.scraper_description(scraper)).to eq 'A scraper to collect structured data from the web.'}
+    end
+
+    context "scraper description is not blank" do
+      before :each do
+        allow(scraper).to receive(:description).and_return('Foo bar')
+      end
+
+      it { expect(helper.scraper_description(scraper)).to eq 'Foo bar'}
+    end
+  end
 end

--- a/spec/helpers/scrapers_helper_spec.rb
+++ b/spec/helpers/scrapers_helper_spec.rb
@@ -20,7 +20,7 @@ describe ScrapersHelper do
     let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com") }
 
     context "scraper description is blank" do
-      it { expect(helper.scraper_description(scraper)).to eq 'A scraper to collect structured data from the web.'}
+      it { expect(helper.scraper_description(scraper)).to eq 'A scraper to collect structured data from the web.' }
     end
 
     context "scraper description is blank and has one scraped domain" do
@@ -46,7 +46,7 @@ describe ScrapersHelper do
         allow(scraper).to receive(:description).and_return('Foo bar')
       end
 
-      it { expect(helper.scraper_description(scraper)).to eq 'Foo bar'}
+      it { expect(helper.scraper_description(scraper)).to eq 'Foo bar' }
     end
   end
 end

--- a/spec/helpers/scrapers_helper_spec.rb
+++ b/spec/helpers/scrapers_helper_spec.rb
@@ -12,9 +12,33 @@ describe ScrapersHelper do
 
   describe "#scraper_description" do
     let(:scraper) { Scraper.new }
+    let(:last_run) { mock_model(Run) }
+    let(:foo_domain) { mock_model(Domain, name: "foo.com") }
+    let(:bar_domain) { mock_model(Domain, name: "bar.com") }
+    let(:www_foo_domain) { mock_model(Domain, name: "www.foo.com") }
+    let(:www_bar_domain) { mock_model(Domain, name: "www.bar.com") }
+    let(:fiddle_domain) { mock_model(Domain, name: "fiddle.com") }
 
     context "scraper description is blank" do
       it { expect(helper.scraper_description(scraper)).to eq 'A scraper to collect structured data from the web.'}
+    end
+
+    context "scraper description is blank and has one scraped domain" do
+      before :each do
+        allow(scraper).to receive(:last_run).and_return(last_run)
+        allow(scraper).to receive(:scraped_domains).and_return([foo_domain])
+      end
+
+      it { expect(helper.scraper_description(scraper)).to eq 'A scraper to collect structured data from foo.com.' }
+    end
+
+    context "scraper description is blank and has five scraped domains" do
+      before :each do
+        allow(scraper).to receive(:last_run).and_return(last_run)
+        allow(scraper).to receive(:scraped_domains).and_return([foo_domain, bar_domain, www_foo_domain, www_bar_domain, fiddle_domain])
+      end
+
+      it { expect(helper.scraper_description(scraper)).to eq 'A scraper to collect structured data from foo.com, bar.com, www.foo.com, and 2 other domains.' }
     end
 
     context "scraper description is not blank" do


### PR DESCRIPTION
To improve the indexing and display of scrapers in search engines, these commits change the description of a scraper page to contain the description the owner has provided.

If they haven't added a description it falls back to a generic description "A scraper to collect structured data from the web."

If they haven't added a description, *but the scraper has a list of scraped domains*, then it adds that as well to make "A scraper to collect structured data from foo.com, bar.com and fiddle.com."

This uses the meta-tags gem and removes the hardcoded description from the application layout. This means that pages without the description set wont have any description anymore. I've added the old description back to the signed_out landing page. Aside from that, I don't think it's a regression to remove the current description from other pages, because it isn't actually a description of the page and so isn't useful to search bots or humans (if they can even see it somewhere).

fixes #663