### PR TITLE
Fix empty scrollbar bug effecting Linux users

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -7,7 +7,7 @@
     @include tablesaw-stack( $grid-float-breakpoint );
 
     @media (min-width: $grid-float-breakpoint) {
-      overflow: scroll;
+      overflow: auto;
     }
 
     tr {


### PR DESCRIPTION
Based on feedback from @henare this should remove scroll bars
that would appear around the data table even if it didn't need
scrolling. This fix doesn't effect Chrome or Firefox on OSX, which
aren't experiencing the bug.

Fixes #622