### PR TITLE
Fix alert sentence

### DIFF
--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -14,7 +14,11 @@
 .container
   - if !current_user.watched_broken_scrapers_ordered_by_urgency.empty?
     .scraper-alert-panel.panel.panel-danger
-      %h2.panel-heading #{pluralize(current_user.watched_broken_scrapers_ordered_by_urgency.count, 'scraper')} you are watching #{current_user.watched_broken_scrapers_ordered_by_urgency.count > 1 ? 'need' : 'needs'} help
+      %h2.panel-heading
+        #{pluralize(current_user.watched_broken_scrapers_ordered_by_urgency.count, 'scraper')}
+        you are watching
+        #{current_user.watched_broken_scrapers_ordered_by_urgency.count > 1 ? 'need' : 'needs'}
+        help
       .scraper-alerts-list.list-group= sync partial: "scraper_with_errors", collection: current_user.watched_broken_scrapers_ordered_by_urgency
     %p= link_to "Manage your watched scrapers", watching_user_path(current_user)
 

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -14,7 +14,7 @@
 .container
   - if !current_user.watched_broken_scrapers_ordered_by_urgency.empty?
     .scraper-alert-panel.panel.panel-danger
-      %h2.panel-heading #{pluralize(current_user.watched_broken_scrapers_ordered_by_urgency.count, 'scraper')} you are watching need help
+      %h2.panel-heading #{pluralize(current_user.watched_broken_scrapers_ordered_by_urgency.count, 'scraper')} you are watching #{current_user.watched_broken_scrapers_ordered_by_urgency.count > 1 ? 'need' : 'needs'} help
       .scraper-alerts-list.list-group= sync partial: "scraper_with_errors", collection: current_user.watched_broken_scrapers_ordered_by_urgency
     %p= link_to "Manage your watched scrapers", watching_user_path(current_user)
 


### PR DESCRIPTION
This corrects the statement to be:

> 1 scraper you are watching needs your help

if there is only one scraper, and:

> 3 scrapers you are watching need your help

if there are several.

fixes #743 