### PR TITLE
Fix scraper list item alignment

### DIFF
--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -287,6 +287,10 @@ a i.fa-clock-o {
     margin: .2em 0 0 .25em;
     width: 4em;
     text-align: right;
+
+    @media (min-width: 40em) {
+      margin-top: .5em;
+    }
   }
 
   .icon-box {

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -324,7 +324,12 @@ a i.fa-clock-o {
   }
 
   .label-danger.pull-right {
+    margin-top: .2em;
     margin-left: 0.25em;
+
+    @media (min-width: 40em) {
+      margin-top: .5em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -324,8 +324,7 @@ a i.fa-clock-o {
   }
 
   .label-danger.pull-right {
-    margin-top: .2em;
-    margin-left: 0.25em;
+    margin: .2em 0 0 .25em;
 
     @media (min-width: 40em) {
       margin-top: .5em;

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -294,11 +294,15 @@ a i.fa-clock-o {
   }
 
   .icon-box {
-    margin: 0 .25em;
+    margin: .1em .25em 0 .25em;
     text-align: center;
 
     @media (min-width: 37em) {
       width: 3em;
+    }
+
+    @media (min-width: 40em) {
+      margin-top: .25em;
     }
 
     .spinner,


### PR DESCRIPTION
This keeps the items on the righthand side of the scraper in a consistent horizontal line. The 'running' and 'timer' icons and the language are aligned to the baseline of the scraper name title. The 'errored' label is centred against the icons because it is text in padding so matching it's text to the baseline doesn't help.

fixes #718

## Before
![screen shot 2015-05-20 at 12 57 37 pm](https://cloud.githubusercontent.com/assets/1239550/7718166/e2785f2a-feef-11e4-9681-3c07393bb3b0.png)

## After
![screen shot 2015-05-20 at 12 57 28 pm](https://cloud.githubusercontent.com/assets/1239550/7718171/e92c28c4-feef-11e4-9e88-d6fe0767c1e4.png)
