### PR TITLE
[WIP] Scale metrics banner

### DIFF
--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -258,3 +258,22 @@
     }
   }
 }
+
+.banner-metrics {
+  padding-bottom: 48px;
+  text-align: center;
+
+  h3 {
+    margin-bottom: 24px;
+  }
+}
+
+.metric-box {
+  margin-bottom: 24px;
+  font-size: $font-size-h4;
+
+  strong {
+    display: block;
+    font-size: $font-size-h1;
+  }
+}

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -260,7 +260,7 @@
 }
 
 .banner-metrics {
-  padding-bottom: 48px;
+  padding-bottom: 24px;
   text-align: center;
 
   h3 {

--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -265,6 +265,7 @@
 
   h3 {
     margin-bottom: 24px;
+    font-weight: normal;
   }
 }
 

--- a/app/views/static/index.html.haml
+++ b/app/views/static/index.html.haml
@@ -9,11 +9,11 @@
   .container
     %h3 This week
     .metric-box.col-sm-4
-      %strong 22,000
+      %strong= number_with_delimiter(Morph::VanityStats.total_pages_scraped_in_last_week)
       web pages scraped
     .metric-box.col-sm-4
-      %strong 750,000
+      %strong= number_with_delimiter(Morph::VanityStats.total_database_rows_updated_in_last_week)
       rows of data collected
     .metric-box.col-sm-4
-      %strong 5,000
+      %strong= number_with_delimiter(Morph::VanityStats.total_api_queries_in_last_week)
       downloads &amp; API queries

--- a/app/views/static/index.html.haml
+++ b/app/views/static/index.html.haml
@@ -4,3 +4,16 @@
   = render "signed_in_index"
 - else
   = render "signed_out_index"
+
+.banner.banner-metrics
+  .container
+    %h3 This week
+    .metric-box.col-sm-4
+      %strong 22,000
+      web pages scraped
+    .metric-box.col-sm-4
+      %strong 750,000
+      rows of data collected
+    .metric-box.col-sm-4
+      %strong 5,000
+      downloads &amp; API queries

--- a/app/views/static/index.html.haml
+++ b/app/views/static/index.html.haml
@@ -7,7 +7,7 @@
 
 .banner.banner-metrics
   .container
-    %h3 This week
+    %h3 This week at morph.io
     .metric-box.col-sm-4
       %strong= number_with_delimiter(Morph::VanityStats.total_pages_scraped_in_last_week)
       web pages scraped

--- a/lib/morph/vanity_stats.rb
+++ b/lib/morph/vanity_stats.rb
@@ -1,0 +1,16 @@
+module Morph
+  class VanityStats
+    # Include rows that have been changed and created
+    def self.total_database_rows_updated_in_last_week
+      Run.where("finished_at > ?", 7.days.ago).sum(:records_added) + Run.where("finished_at > ?", 7.days.ago).sum(:records_changed)
+    end
+
+    def self.total_pages_scraped_in_last_week
+      ConnectionLog.where("created_at > ?", 7.days.ago).count
+    end
+
+    def self.total_api_queries_in_last_week
+      ApiQuery.where("created_at > ?", 7.days.ago).count
+    end
+  end
+end


### PR DESCRIPTION
Demonstrate the scale of activity on morph.io to validate and reenforce that morph is awesome and people should give it a go and use it more.

This adds a banner to the landing page (signed in and out) that shows the scale of activity on morph this week.

Currently this is a static prototype and the styles are still developing.

Closes #119 