### PR TITLE
Fix bad wrapping of intro text on landing page

### DIFF
--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -196,6 +196,10 @@
     padding: 0;
   }
 
+  .col-lg-8 {
+    @include make-lg-column(8.25);
+  }
+
   p a {
     color: #1E241D;
     border-bottom: 2px darken($offset-color, 20%) solid;

--- a/app/views/static/_introducing.md
+++ b/app/views/static/_introducing.md
@@ -4,4 +4,4 @@ At the OpenAustralia Foundation, our civic tech projects rely on information we 
 
 So we made morph.io to look after those scrapers for us and enable collaboration in the open. It's the culmination of everything we've learned.
 
-We're excited to share morph.io with you and can't wait to see what you'll do with it!
+We're excited to share morph.io with you and can't wait to see what you'll do&nbsp;with&nbsp;it!


### PR DESCRIPTION
The single word "it!" on the last line of the introduction text on the landing page is messy.

This adds a couple of non-breaking spaces between the last three words so they always stay together, and also makes the text block slightly wider on wide screens to the last sentence doesn't need to wrap.

fixes #752 

## Before

![screen shot 2015-05-22 at 2 24 14 pm](https://cloud.githubusercontent.com/assets/1239550/7764100/b986f388-008e-11e5-816b-6dcfb5537b73.png)
![screen shot 2015-05-22 at 2 24 31 pm](https://cloud.githubusercontent.com/assets/1239550/7764101/b98a2350-008e-11e5-966c-1c2c52ef3960.png)

## After

![screen shot 2015-05-22 at 2 23 48 pm](https://cloud.githubusercontent.com/assets/1239550/7764105/be9c36f8-008e-11e5-8c33-4b1c27e967ec.png)
![screen shot 2015-05-22 at 2 23 59 pm](https://cloud.githubusercontent.com/assets/1239550/7764106/beaa0a44-008e-11e5-8560-5bbbf24a787b.png)
