### PR TITLE
Hide owner option from new scraper form if user only has one option

### DIFF
--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -13,13 +13,14 @@
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
       .col-sm-6
         = f.input :name do
+          - name_input_field = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
           - if current_user.all_owners.count == 1
-            = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
+            = name_input_field
           - else
             -# Using long-winded form here because simple_form doesn't directly support prepends
             .input-group
               %span.input-group-addon /
-              = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
+              = name_input_field
           %span.help-block Name to give the scraper here and on GitHub
 
     .row

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -6,8 +6,9 @@
       .col-sm-6
         = f.input :original_language_key, collection: Morph::Language.languages_supported.map{|l| [l.human, l.key, {"data-content" => "#{image_tag(l.image_path, size: '20x20')} #{l.human}"}]}, include_blank: false, hint: "The language you would like to write your scraper in. You can change this later.", label: "Language"
     .row
-      .col-sm-2
-        = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
+      - if current_user.all_owners.count > 1
+        .col-sm-2
+          = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
       .col-sm-6
         -# Using long-winded form here because simple_form doesn't directly support prepends
         = f.input :name do

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -6,7 +6,9 @@
       .col-sm-6
         = f.input :original_language_key, collection: Morph::Language.languages_supported.map{|l| [l.human, l.key, {"data-content" => "#{image_tag(l.image_path, size: '20x20')} #{l.human}"}]}, include_blank: false, hint: "The language you would like to write your scraper in. You can change this later.", label: "Language"
     .row
-      - if current_user.all_owners.count > 1
+      - if current_user.all_owners.count == 1
+        = f.input :owner_id, as: "hidden", input_html: { value: current_user.all_owners.first.id }
+      - else
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
       .col-sm-6

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -10,15 +10,15 @@
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
       .col-sm-6
-        - if current_user.all_owners.count > 1
+        - if current_user.all_owners.count == 1
+          = f.input :name, placeholder: "city_of_sydney_development_applications", hint: "Name to give scraper here and on Github"
+        - else
           -# Using long-winded form here because simple_form doesn't directly support prepends
           = f.input :name do
             .input-group
               %span.input-group-addon /
               = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
             %span.help-block Name to give the scraper here and on GitHub
-        - else
-          = f.input :name, placeholder: "city_of_sydney_development_applications", hint: "Name to give scraper here and on Github"
 
     .row
       .col-sm-10.col-md-8

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -17,7 +17,6 @@
           - if current_user.all_owners.count == 1
             = name_input_field
           - else
-            -# Using long-winded form here because simple_form doesn't directly support prepends
             .input-group
               %span.input-group-addon /
               = name_input_field

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -8,13 +8,12 @@
     .row
       - if current_user.all_owners.count == 1
         = f.input :owner_id, as: "hidden", input_html: { value: current_user.id }
+        .col-sm-6
+          = f.input :name, placeholder: "city_of_sydney_development_applications", hint: "Name to give scraper here and on Github"
       - else
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
-      .col-sm-6
-        - if current_user.all_owners.count == 1
-          = f.input :name, placeholder: "city_of_sydney_development_applications", hint: "Name to give scraper here and on Github"
-        - else
+        .col-sm-6
           -# Using long-winded form here because simple_form doesn't directly support prepends
           = f.input :name do
             .input-group

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -10,12 +10,15 @@
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
       .col-sm-6
-        -# Using long-winded form here because simple_form doesn't directly support prepends
-        = f.input :name do
-          .input-group
-            %span.input-group-addon /
-            = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
-          %span.help-block Name to give the scraper here and on GitHub
+        - if current_user.all_owners.count > 1
+          -# Using long-winded form here because simple_form doesn't directly support prepends
+          = f.input :name do
+            .input-group
+              %span.input-group-addon /
+              = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
+            %span.help-block Name to give the scraper here and on GitHub
+        - else
+          = f.input :name, placeholder: "city_of_sydney_development_applications", hint: "Name to give scraper here and on Github"
 
     .row
       .col-sm-10.col-md-8

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -7,7 +7,7 @@
         = f.input :original_language_key, collection: Morph::Language.languages_supported.map{|l| [l.human, l.key, {"data-content" => "#{image_tag(l.image_path, size: '20x20')} #{l.human}"}]}, include_blank: false, hint: "The language you would like to write your scraper in. You can change this later.", label: "Language"
     .row
       - if current_user.all_owners.count == 1
-        = f.input :owner_id, as: "hidden", input_html: { value: current_user.all_owners.first.id }
+        = f.input :owner_id, as: "hidden", input_html: { value: current_user.id }
       - else
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -5,12 +5,14 @@
     .row
       .col-sm-6
         = f.input :original_language_key, collection: Morph::Language.languages_supported.map{|l| [l.human, l.key, {"data-content" => "#{image_tag(l.image_path, size: '20x20')} #{l.human}"}]}, include_blank: false, hint: "The language you would like to write your scraper in. You can change this later.", label: "Language"
+
     .row
       - if current_user.all_owners.count == 1
         = f.input :owner_id, as: "hidden", input_html: { value: current_user.id }
       - else
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
+
       .col-sm-6
         = f.input :name do
           - name_input_field = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"

--- a/app/views/scrapers/new.html.haml
+++ b/app/views/scrapers/new.html.haml
@@ -8,18 +8,19 @@
     .row
       - if current_user.all_owners.count == 1
         = f.input :owner_id, as: "hidden", input_html: { value: current_user.id }
-        .col-sm-6
-          = f.input :name, placeholder: "city_of_sydney_development_applications", hint: "Name to give scraper here and on Github"
       - else
         .col-sm-2
           = f.input :owner_id, collection: current_user.all_owners.map{|o| [o.nickname, o.id, {"data-content" => "#{owner_image(o, 20, false)} #{o.nickname}"}]}, include_blank: false
-        .col-sm-6
-          -# Using long-winded form here because simple_form doesn't directly support prepends
-          = f.input :name do
+      .col-sm-6
+        = f.input :name do
+          - if current_user.all_owners.count == 1
+            = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
+          - else
+            -# Using long-winded form here because simple_form doesn't directly support prepends
             .input-group
               %span.input-group-addon /
               = f.input_field :name, class: "form-control", placeholder:"city_of_sydney_development_applications"
-            %span.help-block Name to give the scraper here and on GitHub
+          %span.help-block Name to give the scraper here and on GitHub
 
     .row
       .col-sm-10.col-md-8


### PR DESCRIPTION
This removes the 'owner' heading and select menu from the form if the user doesn't have a choice, so they can focus on the inputs they can interact with.

It also removes the '/' prepended to the input if the owner block isn't there, because it is confusing to have it present if it isn't dividing anything.

closes #753 

![screen shot 2015-05-22 at 3 58 46 pm](https://cloud.githubusercontent.com/assets/1239550/7765329/24022e06-00a0-11e5-8e13-77c4720896b7.png)
