### PR TITLE
Add basic search meta description

### DIFF
--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,3 +1,5 @@
+- set_meta_tags description: 'Search morph.io for scrapers and users'
+
 .container
   %h1.label-heading
     Search

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,4 +1,4 @@
-- set_meta_tags description: "Search morph.io scrapers and users #{"for ‘" + @q + "’" if @q}"
+- set_meta_tags description: "Search morph.io scrapers and users#{" for ‘" + @q + "’" if @q}"
 
 .container
   %h1.label-heading

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,4 +1,4 @@
-- set_meta_tags description: "Search morph.io for scrapers and users #{"relating to ‘" + @q + "’" if @q}"
+- set_meta_tags description: "Search morph.io scrapers and users #{"for ‘" + @q + "’" if @q}"
 
 .container
   %h1.label-heading

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,4 +1,4 @@
-- set_meta_tags description: 'Search morph.io for scrapers and users'
+- set_meta_tags description: "Search morph.io for scrapers and users #{"relating to ‘" + @q + "’" if @q}"
 
 .container
   %h1.label-heading


### PR DESCRIPTION
This adds a simple meta description to the search page.

If there is no query it simply reads 'Search morph.io scrapers and users'

If there is a query e.g. 'Parliament', it reads 'Search morph.io scrapers and users for ‘Parliament’'

This is a basic first pass at this and does nothing special if there are no results.

closes #739 