### PR TITLE
[For review] Basic running scrapers page and remove 'recently active scrapers' list from landing page

### DIFF
--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -228,6 +228,7 @@ class ScrapersController < ApplicationController
   end
 
   def running
+    @scrapers = Scraper.currently_running
   end
 
   private

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -227,6 +227,9 @@ class ScrapersController < ApplicationController
     authorize! :watchers, @scraper
   end
 
+  def running
+  end
+
   private
 
   def render_error(message)

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -228,7 +228,7 @@ class ScrapersController < ApplicationController
   end
 
   def running
-    @scrapers = Scraper.currently_running
+    @scrapers = Scraper.running
   end
 
   private

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -8,6 +8,7 @@ class Run < ActiveRecord::Base
   has_many :domains, -> { distinct }, through: :connection_logs
 
   scope :finished_successfully, -> { where(status_code: 0) }
+  scope :running, -> { where(finished_at: nil).where("started_at IS NOT NULL") }
 
   delegate :git_url, :full_name, :current_revision_from_repo, to: :scraper, allow_nil: true
   delegate :utime, :stime, to: :metric

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -42,7 +42,7 @@ class Scraper < ActiveRecord::Base
 
   delegate :finished_recently?, :finished_at, :finished_successfully?, :finished_with_errors?, :queued?, :running?, to: :last_run, allow_nil: true
 
-  def self.currently_running
+  def self.running
     Run.running.map(&:scraper).compact
   end
 

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -43,9 +43,7 @@ class Scraper < ActiveRecord::Base
   delegate :finished_recently?, :finished_at, :finished_successfully?, :finished_with_errors?, :queued?, :running?, to: :last_run, allow_nil: true
 
   def self.currently_running
-    running_scrapers = []
-    self.all.map {|scraper| running_scrapers << scraper if scraper.running?}
-    return running_scrapers
+    Run.running.map(&:scraper).compact
   end
 
   def search_data

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -42,6 +42,12 @@ class Scraper < ActiveRecord::Base
 
   delegate :finished_recently?, :finished_at, :finished_successfully?, :finished_with_errors?, :queued?, :running?, to: :last_run, allow_nil: true
 
+  def self.currently_running
+    running_scrapers = []
+    self.all.map {|scraper| running_scrapers << scraper if scraper.running?}
+    return running_scrapers
+  end
+
   def search_data
     {
       full_name: full_name,

--- a/app/views/scrapers/running.html.haml
+++ b/app/views/scrapers/running.html.haml
@@ -1,0 +1,5 @@
+.container
+  .row
+    .col-xs-12
+      %h1 Currently running scrapers
+      .list-group= sync partial: "scraper", collection: Scraper.currently_running

--- a/app/views/scrapers/running.html.haml
+++ b/app/views/scrapers/running.html.haml
@@ -1,5 +1,5 @@
 .container
   .row
     .col-xs-12
-      %h1 Currently running scrapers
+      %h1 Scrapers currently running
       .list-group= sync partial: "scraper", collection: Scraper.currently_running

--- a/app/views/scrapers/running.html.haml
+++ b/app/views/scrapers/running.html.haml
@@ -2,4 +2,4 @@
   .row
     .col-xs-12
       %h1 Scrapers currently running
-      .list-group= sync partial: "scraper", collection: Scraper.currently_running
+      .list-group= sync partial: "scraper", collection: @scrapers

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -31,7 +31,7 @@
               %li= link_to "Dashboard", admin_dashboard_path
               %li= link_to "Owner Metrics", admin_owners_path
               %li= link_to "Background queue", "/admin/jobs", data: {"no-turbolink" => true}
-              %li= link_to "Running scrapers", scrapers_running_path
+              %li= link_to "Running scrapers", running_scrapers_path
 
       %ul.nav.navbar-nav.navbar-right
         %li

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -31,6 +31,7 @@
               %li= link_to "Dashboard", admin_dashboard_path
               %li= link_to "Owner Metrics", admin_owners_path
               %li= link_to "Background queue", "/admin/jobs", data: {"no-turbolink" => true}
+              %li= link_to "Running scrapers", scrapers_running_path
 
       %ul.nav.navbar-nav.navbar-right
         %li

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -37,9 +37,3 @@
             - if org.name
               &mdash;
               = org.name
-    .col-md-6
-      %h2 Recently Active Scrapers
-      %p
-        = link_to scrapers_path do
-          See more of the #{pluralize(Scraper.count, "scraper")}&hellip;
-      .list-group= sync partial: "scraper", collection: Scraper.order(:updated_at => :desc).limit(10)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,10 +85,9 @@ Rails.application.routes.draw do
       post 'github', to: "scrapers#create_github"
       get 'github_form'
       post 'scraperwiki', to: "scrapers#create_scraperwiki"
+      get 'running'
     end
   end
-
-  get 'scrapers/running', to: "scrapers#running"
 
   # These routes with path: "/" need to be at the end
   resources :owners, path: "/", only: [:show, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'scrapers/running', to: "scrapers#running"
+
   # These routes with path: "/" need to be at the end
   resources :owners, path: "/", only: [:show, :update]
   resources :users, path: "/", only: :show


### PR DESCRIPTION
This adds a new page `/scrapers/running` that you can access through the admin dropdown menu. The page shows a list of scrapers currently running and has a heading. Nothing fancy.

@mlandauer This is what's described in issue #757 , but it's different functionality than you currently get from the 'Recently active scrapers' list on the landing page. Does this list of just the currently running scrapers satisfy your needs?

I haven't added a test for the `Scraper.currently_running` class method, but I also see that we don't have testings for `.running?`. I read that it's better to test the direct behaviour that the association, so should I add a tests for the [`.running?`](https://github.com/openaustralia/morph/blob/master/app/models/run.rb#L63-L65) method on Run?

Also this instantiates Scraper.all to get this list so it might be a bit slow on production. I couldn't work out a more performant way to do this sorry.

closes #757 

![screen shot 2015-05-25 at 7 12 24 pm](https://cloud.githubusercontent.com/assets/1239550/7794833/0cecfab0-0312-11e5-9232-bb34d3ee5c8f.png)
![screen shot 2015-05-25 at 7 12 17 pm](https://cloud.githubusercontent.com/assets/1239550/7794834/0cf7404c-0312-11e5-8eea-6854b786de7d.png)
