### PR TITLE
Fix search filters scrollbar issue for Linux users

### DIFF
--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -37,7 +37,6 @@
 
     @media (min-width: $screen-md-min) {
       margin: 0 0 $padding-large-vertical;
-      overflow: auto;
       height: auto;
     }
   }

--- a/app/assets/stylesheets/search.css.scss
+++ b/app/assets/stylesheets/search.css.scss
@@ -32,7 +32,6 @@
   h2 {
     margin: 0;
     font-weight: normal;
-    overflow: hidden;
     height: 0;
 
     @media (min-width: $screen-md-min) {


### PR DESCRIPTION
This removes the setting of the overflow property on the search filters heading. It was being set as part of the styles to hide the heading on small screens, but I've realised it wasn't necessary here at all.

fixes #737 