### PR TITLE
Add content for <title> to Search page

### DIFF
--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Search"
+- content_for :title, "Search#{" ‘" + @q + "’" if @q}"
 - set_meta_tags description: "Search morph.io scrapers and users#{" for ‘" + @q + "’" if @q}"
 
 .container

--- a/app/views/search/search.html.haml
+++ b/app/views/search/search.html.haml
@@ -1,3 +1,4 @@
+- content_for :title, "Search"
 - set_meta_tags description: "Search morph.io scrapers and users#{" for ‘" + @q + "’" if @q}"
 
 .container


### PR DESCRIPTION
This adds a simple title to the search page in the pattern we use through the site "morph.io: $page":

> "morph.io: Search"

If there is a query, it also adds that to the title.

![screen shot 2015-05-25 at 7 36 11 pm](https://cloud.githubusercontent.com/assets/1239550/7795148/5b4a29f0-0315-11e5-99d2-4c613eab3994.png)

That's a pattern I noticed at DuckDuckGo.

fixes #763 