### PR TITLE
[WIP] New users list

### DIFF
--- a/app/assets/stylesheets/_landing_page.scss
+++ b/app/assets/stylesheets/_landing_page.scss
@@ -263,6 +263,10 @@
   }
 }
 
+.new-users-block {
+  margin: 24px 0;
+}
+
 .banner-metrics {
   padding-bottom: 24px;
   text-align: center;

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -41,3 +41,9 @@
     font-size: $font-size-large;
   }
 }
+
+.owner-list-simple {
+  .owner-item {
+    margin-bottom: $padding-large-vertical;
+  }
+}

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -15,7 +15,7 @@
   = render "broken_scrapers"
 
   .row
-    .col-xs-12
+    .new-users-block.col-xs-12
       %h2
         %small.pre-heading Recent new users
         Welcome to morph.io

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -21,7 +21,7 @@
         - User.all.order(created_at: :desc).limit(10).each do |user|
           %li
             = link_to user do
-              = owner_image(user, 20)
+              = owner_image(user, 60)
       %p
         = link_to users_path do
           See more of the #{pluralize(User.count, "user")}&hellip;

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -17,7 +17,7 @@
   .row
     .col-xs-12
       %h2 Recent New Users
-      %ul.list-unstyled
+      %ul.list-unstyled.list-inline
         - User.all.order(created_at: :desc).limit(10).each do |user|
           %li
             = link_to user do

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -28,15 +28,6 @@
             - if user.name
               &mdash;
               = user.name
-      %h2 Organizations with Scrapers
-      %ul.list-unstyled
-        - Organization.all_with_scrapers.each do |org|
-          %li
-            = owner_image(org, 20)
-            = link_to org.nickname, org
-            - if org.name
-              &mdash;
-              = org.name
     .col-md-6
       %h2 Recently Active Scrapers
       %p

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -21,9 +21,7 @@
         Welcome to morph.io
       %ul.list-unstyled.list-inline
         - User.all.order(created_at: :desc).limit(8).each do |user|
-          %li
-            = link_to user do
-              = owner_image(user, 60)
+          %li= link_to owner_image(user, 60), user
       %p
         = link_to users_path do
           See more of the #{pluralize(User.count, "user")}&hellip;

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -20,7 +20,7 @@
         %small.pre-heading Recent new users
         Welcome to morph.io
       %ul.list-unstyled.list-inline
-        - User.all.order(created_at: :desc).limit(10).each do |user|
+        - User.all.order(created_at: :desc).limit(8).each do |user|
           %li
             = link_to user do
               = owner_image(user, 60)

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -22,9 +22,7 @@
       %ul.list-unstyled.list-inline
         - User.all.order(created_at: :desc).limit(8).each do |user|
           %li= link_to owner_image(user, 60), user
-      %p
-        = link_to users_path do
-          See more of the #{pluralize(User.count, "user")}&hellip;
+      %p= link_to "See more of the #{pluralize(User.count, "user")}…", users_path
     .col-md-6
       %h2 Recently Active Scrapers
       %p

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -20,11 +20,8 @@
       %ul.list-unstyled
         - User.all.order(created_at: :desc).limit(10).each do |user|
           %li
-            = owner_image(user, 20)
-            = link_to user.nickname, user
-            - if user.name
-              &mdash;
-              = user.name
+            = link_to user do
+              = owner_image(user, 20)
       %p
         = link_to users_path do
           See more of the #{pluralize(User.count, "user")}&hellip;

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -15,7 +15,7 @@
   = render "broken_scrapers"
 
   .row
-    .col-md-6
+    .col-xs-12
       %h2 Recent New Users
       %p
         = link_to users_path do

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -19,10 +19,10 @@
       %h2
         %small.pre-heading Recent new users
         Welcome to morph.io
-      %ul.list-unstyled.list-inline
+      %ul.owner-list-simple.list-unstyled.list-inline
         - # TODO Don't show users who have a 'default' Github identicon avartar
         - User.all.order(created_at: :desc).limit(8).each do |user|
-          %li= link_to owner_image(user, 60), user
+          %li.owner-item= link_to owner_image(user, 60), user
       %p= link_to "See more of the #{pluralize(User.count, "user")}…", users_path
     .col-md-6
       %h2 Recently Active Scrapers

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -20,7 +20,6 @@
         %small.pre-heading Recent new users
         Welcome to morph.io
       %ul.owner-list-simple.list-unstyled.list-inline
-        - # TODO Don't show users who have a 'default' Github identicon avartar
-        - User.all.order(created_at: :desc).limit(8).each do |user|
+        - User.where.not(name: nil).order(created_at: :desc).limit(8).each do |user|
           %li.owner-item= link_to owner_image(user, 60), user
       %p= link_to "See more of the #{pluralize(User.count, "user")}…", users_path

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -20,6 +20,7 @@
         %small.pre-heading Recent new users
         Welcome to morph.io
       %ul.list-unstyled.list-inline
+        - # TODO Don't show users who have a 'default' Github identicon avartar
         - User.all.order(created_at: :desc).limit(8).each do |user|
           %li= link_to owner_image(user, 60), user
       %p= link_to "See more of the #{pluralize(User.count, "user")}…", users_path

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -16,7 +16,9 @@
 
   .row
     .col-xs-12
-      %h2 Recent New Users
+      %h2
+        %small.pre-heading Recent new users
+        Welcome to morph.io
       %ul.list-unstyled.list-inline
         - User.all.order(created_at: :desc).limit(10).each do |user|
           %li

--- a/app/views/static/_signed_in_index.html.haml
+++ b/app/views/static/_signed_in_index.html.haml
@@ -17,9 +17,6 @@
   .row
     .col-xs-12
       %h2 Recent New Users
-      %p
-        = link_to users_path do
-          See more of the #{pluralize(User.count, "user")}&hellip;
       %ul.list-unstyled
         - User.all.order(created_at: :desc).limit(10).each do |user|
           %li
@@ -28,6 +25,9 @@
             - if user.name
               &mdash;
               = user.name
+      %p
+        = link_to users_path do
+          See more of the #{pluralize(User.count, "user")}&hellip;
     .col-md-6
       %h2 Recently Active Scrapers
       %p


### PR DESCRIPTION
This reworks the new users list to put more focus on the people. It makes the images bigger, and removes the names. You can still get the user's nickname with a tooltip on hover.

It removes the organisation list, because this list is very static and not very useful to users.

The users list has it's own row, so the the scrapers list (which we're soon to remove, see #767 ) slots in underneath.

**TODO: Don't show users who only have the generated identicon**, like ![screen shot 2015-05-26 at 3 31 01 pm](https://cloud.githubusercontent.com/assets/1239550/7805802/4d5ebf16-03bc-11e5-8ba8-d625f37eb4ff.png)

The purpose of this change is undermined a bit if there are lots of the identicon avatars. It makes the users seem like robots even! I can't work out how to filter them out unfortunately. Any ideas @mlandauer ?

closes #759 
closes #758 

## Before
![screen shot 2015-05-26 at 3 32 09 pm](https://cloud.githubusercontent.com/assets/1239550/7805807/6a275586-03bc-11e5-9d48-2c4f6530acc5.png)

## After
![screen shot 2015-05-26 at 3 32 49 pm](https://cloud.githubusercontent.com/assets/1239550/7805818/89d0ce58-03bc-11e5-9ffc-49589732cbe8.png)
