### PR TITLE
Sort the scrapers index by most recently created first

### DIFF
--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -12,7 +12,7 @@ class ScrapersController < ApplicationController
   end
 
   def index
-    @scrapers = Scraper.accessible_by(current_ability).order(:updated_at => :desc).page(params[:page])
+    @scrapers = Scraper.accessible_by(current_ability).order(:created_at => :desc).page(params[:page])
   end
 
   def new


### PR DESCRIPTION
Whether a scrapers have been recently active isn't very meaningful
to a user, unless it's their scrapers. On the scraper index,
data created, is slightly  more helpful because at least they can
checkout what's new, which could be of interest.

closes #761