### PR TITLE
Make Runner tests more reliable

### DIFF
--- a/spec/lib/morph/runner_spec.rb
+++ b/spec/lib/morph/runner_spec.rb
@@ -56,13 +56,6 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
           raise Sidekiq::Shutdown
         end
       end}.to raise_error(Sidekiq::Shutdown)
-      expect(logs.join).to eq [
-        "Injecting configuration and compiling...\n",
-        "Injecting scraper and running...\n",
-        "Started!\n",
-        "1...\n",
-        "2...\n"
-      ].join
       run.reload
       expect(run).to be_running
       # We expect the container to still be running
@@ -72,11 +65,15 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
 
       # Now, we simulate the queue restarting the job
       started_at = run.started_at
-      logs = []
       runner.go do |s, c|
         logs << c
       end
       expect(logs.join).to eq [
+        "Injecting configuration and compiling...\n",
+        "Injecting scraper and running...\n",
+        "Started!\n",
+        "1...\n",
+        "2...\n",
         "3...\n",
         "4...\n",
         "5...\n",

--- a/spec/lib/morph/runner_spec.rb
+++ b/spec/lib/morph/runner_spec.rb
@@ -57,13 +57,13 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
           raise Sidekiq::Shutdown
         end
       end}.to raise_error(Sidekiq::Shutdown)
-      expect(logs).to eq [
+      expect(logs.join).to eq [
         "Injecting configuration and compiling...\n",
         "Injecting scraper and running...\n",
         "Started!\n",
         "1...\n",
         "2...\n"
-      ]
+      ].join
       run.reload
       expect(run).to be_running
       # We expect the container to still be running
@@ -78,7 +78,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
         logs << c
         #puts c
       end
-      expect(logs).to eq [
+      expect(logs.join).to eq [
         "3...\n",
         "4...\n",
         "5...\n",
@@ -88,7 +88,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
         "9...\n",
         "10...\n",
         "Finished!\n"
-      ]
+      ].join
       run.reload
       # The start time shouldn't have changed
       expect(run.started_at).to eq started_at
@@ -128,13 +128,13 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
           raise Sidekiq::Shutdown
         end
       end}.to raise_error(Sidekiq::Shutdown)
-      expect(logs).to eq [
+      expect(logs.join).to eq [
         "Injecting configuration and compiling...\n",
         "Injecting scraper and running...\n",
         "Started!\n",
         "1...\n",
         "2...\n"
-      ]
+      ].join
       run.reload
       expect(run).to be_running
       # We expect the container to still be running
@@ -153,7 +153,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
         #puts c
       end
       # TODO: Really we only want to get newer logs
-      expect(logs).to eq [
+      expect(logs.join).to eq [
         "Started!\n",
         "1...\n",
         "2...\n",
@@ -166,7 +166,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
         "9...\n",
         "10...\n",
         "Finished!\n"
-      ]
+      ].join
       run.reload
       # The start time shouldn't have changed
       expect(run.started_at).to eq started_at

--- a/spec/lib/morph/runner_spec.rb
+++ b/spec/lib/morph/runner_spec.rb
@@ -52,8 +52,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
       container_count = Morph::DockerUtils.stopped_containers.count
       expect {runner.go_with_logging do |s, c|
         logs << c
-        #puts c
-        if c == "2...\n"
+        if c.include? "2..."
           raise Sidekiq::Shutdown
         end
       end}.to raise_error(Sidekiq::Shutdown)
@@ -76,7 +75,6 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
       logs = []
       runner.go do |s, c|
         logs << c
-        #puts c
       end
       expect(logs.join).to eq [
         "3...\n",
@@ -123,8 +121,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
       container_count = Morph::DockerUtils.stopped_containers.count
       expect {runner.go do |s, c|
         logs << c
-        #puts c
-        if c == "2...\n"
+        if c.include? "2..."
           raise Sidekiq::Shutdown
         end
       end}.to raise_error(Sidekiq::Shutdown)
@@ -204,7 +201,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
       container_count = Morph::DockerUtils.stopped_containers.count
       runner.go do |s, c|
         logs << c
-        if c == "2...\n"
+        if c.include? "2..."
           # Putting the stop code in another thread (which is essentially
           # similar to how it works on morph.io for real)
           # If we don't do this we get a "Closed stream (IOError)" which I
@@ -212,7 +209,7 @@ ScraperWiki.save_sqlite(["state"], {"state" => "finished"})
           Thread.new { runner.stop! }
         end
       end
-      expect(logs.last == "2...\n" || logs.last == "3...\n").to eq true
+      expect(logs.join.include?("2...") || logs.join.include?("3...")).to eq true
       expect(Morph::DockerUtils.stopped_containers.count).to eq container_count
       expect(run.database.first_ten_rows).to eq [{ 'state' => 'started' }]
       expect(run.status_code).to eq 137


### PR DESCRIPTION
This makes runner tests more reliable by being less strict about the log output.

Since we're not supposed to be testing how exactly the log lines are split up in these tests, and how well the lines are split is not important to the application, you could argue we should merge this. On the other hand, are we just ignoring a real problem by doing this?

I'm a little torn, hence the pull request.

Closes #807.