### PR TITLE
Increase container memory limit to 512MB

### DIFF
--- a/app/views/documentation/_limits.md
+++ b/app/views/documentation/_limits.md
@@ -4,7 +4,7 @@ this.
 However, we do impose a couple of hard limits on running scrapers so they don't
 take up too many resources
 
-* max 100 MB memory
+* max 512 MB memory
 * max 24 hours run time for a single run
 
 If a scraper runs out of memory or runs too long it will get killed

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -20,10 +20,8 @@ module Morph
     end
 
     # Memory limit applied to running container (in bytes)
-    # On a 1G machine we're allowing a max of 10 containers to run at
-    # a time. So, 100M
     def self.memory_limit
-      100 * 1024 * 1024
+      512 * 1024 * 1024
     end
 
     def self.compile_and_start_run(


### PR DESCRIPTION
Fixes #898.

Can be merged and deployed after #905 is fixed.

Bleh, I accidentally pushed to the wrong branch. Hence all the stupid reverts.