### PR TITLE
Webhooks

### DIFF
--- a/app/assets/javascripts/scrapers.js.coffee
+++ b/app/assets/javascripts/scrapers.js.coffee
@@ -106,3 +106,6 @@ $ ->
     .on 'cocoon:before-remove', (e, removedItem) ->
       $(this).data('remove-timeout', 500)
       removedItem.fadeOut('fast')
+
+  # Enable Bootstrap's tooltips for webhook delivery status
+  $('[data-toggle="tooltip"]').tooltip animation: false

--- a/app/assets/stylesheets/scrapers.css.scss
+++ b/app/assets/stylesheets/scrapers.css.scss
@@ -236,6 +236,21 @@ span.internalout {
   margin-bottom: 4em;
 }
 
+#webhooks {
+  .webhook-status {
+    &.success {
+      color: #6cc644;
+    }
+    &.failure {
+      color: #bd2c00;
+    }
+  }
+
+  .tooltip-inner {
+    max-width: 400px;
+  }
+}
+
 #scraper_run input {
   width: 200px;
 }

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -313,6 +313,7 @@ class ScrapersController < ApplicationController
 
   def scraper_params
     params.require(:scraper).permit(:auto_run, variables_attributes: [
-      :id, :name, :value, :_destroy])
+      :id, :name, :value, :_destroy], webhooks_attributes: [
+      :id, :url, :_destroy])
   end
 end

--- a/app/helpers/scrapers_helper.rb
+++ b/app/helpers/scrapers_helper.rb
@@ -52,4 +52,14 @@ module ScrapersHelper
       end
     end
   end
+
+  def webhook_last_delivery_status(webhook)
+    if webhook.last_delivery.blank?
+      'unknown'
+    elsif webhook.last_delivery.success?
+      'success'
+    else
+      'failure'
+    end
+  end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -103,4 +103,12 @@ class Run < ActiveRecord::Base
   def env_variables
     Variable.to_hash(variables)
   end
+
+  # Called when a run has finished. Perform any post-run work here.
+  def finished!
+    return unless scraper.present?
+    scraper.update_sqlite_db_size
+    scraper.reindex
+    scraper.reload
+  end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -106,7 +106,6 @@ class Run < ActiveRecord::Base
 
   # Called when a run has finished. Perform any post-run work here.
   def finished!
-    return unless scraper.present?
     scraper.update_sqlite_db_size
     scraper.reindex
     scraper.reload

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -110,5 +110,6 @@ class Run < ActiveRecord::Base
     scraper.update_sqlite_db_size
     scraper.reindex
     scraper.reload
+    scraper.deliver_webhooks(self)
   end
 end

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -453,6 +453,13 @@ class Scraper < ActiveRecord::Base
     # TODO: Add repo link
   end
 
+  def deliver_webhooks(run)
+    webhooks.each do |webhook|
+      webhook_delivery = webhook.deliveries.create!(run: run)
+      DeliverWebhookWorker.perform_async(webhook_delivery.id)
+    end
+  end
+
   private
 
   def not_used_on_github

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -23,6 +23,8 @@ class Scraper < ActiveRecord::Base
   belongs_to :create_scraper_progress
   has_many :variables
   accepts_nested_attributes_for :variables, allow_destroy: true
+  has_many :webhooks
+  accepts_nested_attributes_for :webhooks, allow_destroy: true
   validates_associated :variables
   delegate :sqlite_total_rows, to: :database
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,0 +1,3 @@
+class Webhook < ActiveRecord::Base
+  belongs_to :scraper
+end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -4,6 +4,6 @@ class Webhook < ActiveRecord::Base
   validates :url, presence: true
 
   def last_delivery
-    deliveries.order(created_at: :desc).first
+    deliveries.order(sent_at: :desc).first
   end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -2,4 +2,8 @@ class Webhook < ActiveRecord::Base
   belongs_to :scraper
   has_many :deliveries, class_name: WebhookDelivery
   validates :url, presence: true
+
+  def last_delivery
+    deliveries.order(created_at: :desc).first
+  end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,4 +1,5 @@
 class Webhook < ActiveRecord::Base
   belongs_to :scraper
   has_many :deliveries, class_name: WebhookDelivery
+  validates :url, presence: true
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,3 +1,4 @@
 class Webhook < ActiveRecord::Base
   belongs_to :scraper
+  # TODO: has_many :deliveries, class_name: WebhookDeliveries
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,4 +1,4 @@
 class Webhook < ActiveRecord::Base
   belongs_to :scraper
-  # TODO: has_many :deliveries, class_name: WebhookDeliveries
+  has_many :deliveries, class_name: WebhookDelivery
 end

--- a/app/models/webhook_delivery.rb
+++ b/app/models/webhook_delivery.rb
@@ -1,4 +1,10 @@
 class WebhookDelivery < ActiveRecord::Base
+  SUCCESSFUL_STATUSES = 200..299
+
   belongs_to :webhook
   belongs_to :run
+
+  def success?
+    SUCCESSFUL_STATUSES.include?(response_code)
+  end
 end

--- a/app/models/webhook_delivery.rb
+++ b/app/models/webhook_delivery.rb
@@ -1,0 +1,4 @@
+class WebhookDelivery < ActiveRecord::Base
+  belongs_to :webhook
+  belongs_to :run
+end

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -1,0 +1,21 @@
+:markdown
+  # Webhooks
+
+  Webhooks allow you to run custom code when one of your scrapers has finished
+  running on morph.io. When a webhook is triggered, we'll send a HTTP POST
+  request to the webhook's configured URL. Webhooks can be used to transform
+  data into different formats, send out notifications, update an archive, or
+  even run some realtime analysis.
+
+  Webhooks can be installed on any of your scrapers. Once installed, they will
+  be triggered each time that scraper finishes running.
+
+  ## Payloads
+
+  Webhooks currently just make an empty HTTP POST request to the specified url.
+  If you'd like the webhooks to have some state you'll need to put that state in
+  the webhook url, either as the path or as GET parameters. If there's something
+  specific you'd like included in the webhook payload then please
+  [ask a question on our help forum](https://help.morph.io/).
+
+

--- a/app/views/layouts/documentation.html.haml
+++ b/app/views/layouts/documentation.html.haml
@@ -10,6 +10,7 @@
           = bs_nav_link 'Using any library in your scraper', libraries_documentation_index_path
           = bs_nav_link 'Choose language version', language_version_documentation_index_path
           = bs_nav_link 'Secret values', secret_values_documentation_index_path
+          = bs_nav_link 'Webhooks', webhooks_documentation_index_path
           = bs_nav_link "Scraping JavaScript heavy sites", scraping_javascript_sites_documentation_index_path
           = bs_nav_link "Moving from ScraperWiki Classic", scraperwiki_documentation_index_path
           = bs_nav_link "How to use the API", api_documentation_index_path

--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -22,6 +22,9 @@
     = f.button :submit, "Update"
 
   %h3 Webhooks
+  %p
+    We'll make an HTTP POST request to each webhook url whenever this scraper finishes running.
+    = link_to 'Read documentation', webhooks_documentation_index_path
   .row
     .col-sm-3
       %label URL

--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -20,3 +20,24 @@
           Add variable
   - if can? :update, @scraper
     = f.button :submit, "Update"
+
+  %h3 Webhooks
+  .row
+    .col-sm-3
+      %label URL
+  #webhooks
+    = f.fields_for :webhooks do |webhook_form|
+      .nested-fields
+        .row
+          .col-sm-3
+            = webhook_form.input :url, input_html: {class: "url"}
+          .col-sm-1
+            = link_to_remove_association webhook_form do
+              %i.fa.fa-times-circle.fa-2x
+    .links
+      - if can? :update, @scraper
+        = link_to_add_association f, :webhooks do
+          %i.fa.fa-plus-circle.fa-2x
+          Add webhook
+  - if can? :update, @scraper
+    = f.button :submit, "Update"

--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -33,7 +33,16 @@
       .nested-fields
         .row
           .col-sm-3
-            = webhook_form.input :url, input_html: {class: "url"}
+            = webhook_form.input :url, wrapper: :vertical_input_group do
+              %span.webhook-status.input-group-addon{class: webhook_last_delivery_status(webhook_form.object)}
+                - if webhook_form.object.deliveries.any?
+                  - if webhook_form.object.last_delivery.success?
+                    %span.fa.fa-check{data: {toggle: 'tooltip'}, title: 'Last delivery was successful.'}
+                  - else
+                    %span.fa.fa-warning{data: {toggle: 'tooltip'}, title: "Last delivery was not successful. Invalid HTTP Response: #{webhook_form.object.last_delivery.response_code}."}
+                - else
+                  %span.fa.fa-plug{data: {toggle: 'tooltip'}, title: 'No deliveries yet'}
+              = webhook_form.input_field :url, class: 'form-control'
           .col-sm-1
             = link_to_remove_association webhook_form do
               %i.fa.fa-times-circle.fa-2x

--- a/app/views/scrapers/_webhook_fields.html.haml
+++ b/app/views/scrapers/_webhook_fields.html.haml
@@ -1,0 +1,7 @@
+.nested-fields
+  .row
+    .col-sm-3
+      = f.input :url, input_html: {class: "name"}
+    .col-sm-1
+      = link_to_remove_association f do
+        %i.fa.fa-times-circle.fa-2x

--- a/app/views/scrapers/_webhook_fields.html.haml
+++ b/app/views/scrapers/_webhook_fields.html.haml
@@ -1,7 +1,10 @@
 .nested-fields
   .row
     .col-sm-3
-      = f.input :url, input_html: {class: "name"}
+      .webhook.input-group{class: 'unknown'}
+        %span.webhook-status.input-group-addon
+          %span.fa.fa-plug{data: {toggle: 'tooltip'}, title: 'No deliveries yet'}
+        = f.input :url, input_html: {class: "name"}
     .col-sm-1
       = link_to_remove_association f do
         %i.fa.fa-times-circle.fa-2x

--- a/app/workers/deliver_webhook_worker.rb
+++ b/app/workers/deliver_webhook_worker.rb
@@ -1,0 +1,13 @@
+class DeliverWebhookWorker
+  include Sidekiq::Worker
+  sidekiq_options backtrace: true
+
+  def perform(webhook_delivery_id)
+    webhook_delivery = WebhookDelivery.find(webhook_delivery_id)
+    res = Faraday.post(webhook_delivery.webhook.url)
+    webhook_delivery.update_attributes(
+      response_code: res.status,
+      sent_at: DateTime.now
+    )
+  end
+end

--- a/app/workers/deliver_webhook_worker.rb
+++ b/app/workers/deliver_webhook_worker.rb
@@ -4,9 +4,9 @@ class DeliverWebhookWorker
 
   def perform(webhook_delivery_id)
     webhook_delivery = WebhookDelivery.find(webhook_delivery_id)
-    res = Faraday.post(webhook_delivery.webhook.url)
+    response = Faraday.post(webhook_delivery.webhook.url)
     webhook_delivery.update_attributes(
-      response_code: res.status,
+      response_code: response.status,
       sent_at: DateTime.now
     )
   end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -122,6 +122,21 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
+  # From https://github.com/plataformatec/simple_form/wiki/How-to-use-Bootstrap-3-input-group-in-Simple-Form
+  config.wrappers :vertical_input_group, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use :label, class: 'control-label'
+
+    b.wrapper tag: 'div' do |ba|
+      ba.wrapper tag: 'div', class: 'input-group col-sm-12' do |append|
+        append.use :input, class: 'form-control'
+      end
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
   # Wrappers for forms and inputs using the Bootstrap toolkit.
   # Check the Bootstrap docs (http://getbootstrap.com)
   # to learn about the different styles for forms and inputs,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
       get 'language_version'
       get 'scraperwiki'
       get "examples/australian_members_of_parliament"
+      get 'webhooks'
     end
   end
 

--- a/db/migrate/20160125224701_create_webhooks.rb
+++ b/db/migrate/20160125224701_create_webhooks.rb
@@ -1,0 +1,10 @@
+class CreateWebhooks < ActiveRecord::Migration
+  def change
+    create_table :webhooks do |t|
+      t.references :scraper, index: true
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160125231228_create_webhook_deliveries.rb
+++ b/db/migrate/20160125231228_create_webhook_deliveries.rb
@@ -1,0 +1,12 @@
+class CreateWebhookDeliveries < ActiveRecord::Migration
+  def change
+    create_table :webhook_deliveries do |t|
+      t.references :webhook, index: true
+      t.references :run, index: true
+      t.datetime :sent_at
+      t.integer :response_code
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151022011707) do
+ActiveRecord::Schema.define(version: 20160125224701) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "namespace"
@@ -207,20 +207,20 @@ ActiveRecord::Schema.define(version: 20151022011707) do
   add_index "runs", ["scraper_id"], name: "index_runs_on_scraper_id", using: :btree
 
   create_table "scrapers", force: true do |t|
-    t.string   "name",                       default: "",    null: false
+    t.string   "name",                                 default: "",    null: false
     t.string   "description"
     t.integer  "github_id"
-    t.integer  "owner_id",                                   null: false
+    t.integer  "owner_id",                                             null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "full_name"
     t.string   "github_url"
     t.string   "git_url"
-    t.boolean  "auto_run",                   default: false, null: false
+    t.boolean  "auto_run",                             default: false, null: false
     t.string   "scraperwiki_url"
     t.integer  "forked_by_id"
     t.string   "original_language_key"
-    t.integer  "repo_size",                  default: 0,     null: false
+    t.integer  "repo_size",                            default: 0,     null: false
     t.integer  "sqlite_db_size",             limit: 8, default: 0,     null: false
     t.integer  "create_scraper_progress_id"
   end
@@ -241,5 +241,14 @@ ActiveRecord::Schema.define(version: 20151022011707) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "webhooks", force: true do |t|
+    t.integer  "scraper_id"
+    t.string   "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "webhooks", ["scraper_id"], name: "index_webhooks_on_scraper_id", using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160125224701) do
+ActiveRecord::Schema.define(version: 20160125231228) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "namespace"
@@ -241,6 +241,18 @@ ActiveRecord::Schema.define(version: 20160125224701) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "webhook_deliveries", force: true do |t|
+    t.integer  "webhook_id"
+    t.integer  "run_id"
+    t.datetime "sent_at"
+    t.integer  "response_code"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "webhook_deliveries", ["run_id"], name: "index_webhook_deliveries_on_run_id", using: :btree
+  add_index "webhook_deliveries", ["webhook_id"], name: "index_webhook_deliveries_on_webhook_id", using: :btree
 
   create_table "webhooks", force: true do |t|
     t.integer  "scraper_id"

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -133,12 +133,8 @@ module Morph
         )
       end
       Morph::Database.tidy_data_path(run.data_path)
-      if run.scraper
-        run.scraper.update_sqlite_db_size
-        run.scraper.reindex
-        run.scraper.reload
-        sync_update run.scraper
-      end
+      run.finished!
+      sync_update run.scraper if run.scraper
     end
 
     # Note that cleanup is automatically done by the process on the

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -133,8 +133,11 @@ module Morph
         )
       end
       Morph::Database.tidy_data_path(run.data_path)
-      run.finished!
-      sync_update run.scraper if run.scraper
+
+      if run.scraper
+        run.finished!
+        sync_update run.scraper
+      end
     end
 
     # Note that cleanup is automatically done by the process on the

--- a/spec/fixtures/vcr_cassettes/webhook_delivery.yml
+++ b/spec/fixtures/vcr_cassettes/webhook_delivery.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://requestb.in/x3pcr8x3
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Date:
+      - Thu, 28 Jan 2016 22:47:38 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '2'
+      Sponsored-By:
+      - https://www.runscope.com
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: ok
+    http_version: 
+  recorded_at: Thu, 28 Jan 2016 22:47:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -51,4 +51,13 @@ describe Run do
       it { expect(run.env_variables).to eq({}) }
     end
   end
+
+  describe "#finished!" do
+    let(:scraper) { mock_model(Scraper, update_sqlite_db_size: true, reindex: true, reload: true) }
+    let(:run) { Run.new(scraper: scraper) }
+    it "should call relevant methods on the scraper" do
+      expect(scraper).to receive(:deliver_webhooks).with(run)
+      run.finished!
+    end
+  end
 end

--- a/spec/models/webhook_delivery_spec.rb
+++ b/spec/models/webhook_delivery_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WebhookDelivery, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/webhook_delivery_spec.rb
+++ b/spec/models/webhook_delivery_spec.rb
@@ -1,5 +1,10 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe WebhookDelivery, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context '#success?' do
+    it 'returns true if the status code is 2xx' do
+      webhook_delivery = WebhookDelivery.new(response_code: 200)
+      expect(webhook_delivery.success?).to be true
+    end
+  end
 end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Webhook, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe Webhook, type: :model do
     expect(webhook.errors.keys).to eq([:url])
   end
 
-  it "should have a last delivery" do
-    webhook = Webhook.create!(url: 'https://example.org')
-    delivery1 = webhook.deliveries.create!(created_at: 1.hour.ago)
-    delivery2 = webhook.deliveries.create!(created_at: 2.hours.ago)
-    expect(webhook.last_delivery).to eq(delivery1)
+  describe "#last_delivery" do
+    it "should return the most recently sent delivery" do
+      webhook = Webhook.create!(url: 'https://example.org')
+      delivery1 = webhook.deliveries.create!(created_at: 3.hours.ago, sent_at: 1.hour.ago)
+      delivery2 = webhook.deliveries.create!(created_at: 2.hours.ago, sent_at: 2.hours.ago)
+      expect(webhook.last_delivery).to eq(delivery1)
+    end
   end
 end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe Webhook, type: :model do
     expect(webhook).to_not be_valid
     expect(webhook.errors.keys).to eq([:url])
   end
+
+  it "should have a last delivery" do
+    webhook = Webhook.create!(url: 'https://example.org')
+    delivery1 = webhook.deliveries.create!(created_at: 1.hour.ago)
+    delivery2 = webhook.deliveries.create!(created_at: 2.hours.ago)
+    expect(webhook.last_delivery).to eq(delivery1)
+  end
 end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe Webhook, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Webhook, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "should require a url" do
+    webhook = Webhook.new
+    expect(webhook).to_not be_valid
+    expect(webhook.errors.keys).to eq([:url])
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,10 @@ end
 # just buffer. It took way too long to figure out where the problem was!
 WebMock::HttpLibAdapters::ExconAdapter.disable!
 
+# See https://github.com/mperham/sidekiq/wiki/Testing for details
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
 RSpec.configure do |config|
   # ## Mock Framework
   #
@@ -85,4 +89,9 @@ RSpec.configure do |config|
 
   config.filter_run_excluding docker: true if ENV['DONT_RUN_DOCKER_TESTS']
   config.filter_run_excluding slow: true unless ENV['RUN_SLOW_TESTS']
+
+  # Make sure sidekiq jobs don't linger between tests
+  config.before(:each) do
+      Sidekiq::Worker.clear_all
+    end
 end

--- a/spec/workers/deliver_webhook_worker_spec.rb
+++ b/spec/workers/deliver_webhook_worker_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe DeliverWebhookWorker, :vcr do
+  it 'works' do
+    VCR.use_cassette('webhook_delivery') do
+      webhook = Webhook.create!(url: 'http://requestb.in/x3pcr8x3')
+      webhook_delivery = webhook.deliveries.create!
+      DeliverWebhookWorker.new.perform(webhook_delivery.id)
+      webhook_delivery.reload
+      expect(webhook_delivery.response_code).to be(200)
+      expect(webhook_delivery.sent_at).to be_within(1.minute).of(DateTime.now)
+    end
+  end
+end


### PR DESCRIPTION
I've made a start on adding webhooks to scrapers. This is a work in progress but I wanted to get some feedback on the implementation before I get into refactoring and writing tests/docs.

![screen shot 2016-01-26 at 10 42 27](https://cloud.githubusercontent.com/assets/22996/12578560/84e32b52-c419-11e5-85f7-03790001675f.png)

Some thoughts:

What do we want to do about webhook failures? I know sidekiq will retry with backoff but perhaps don't want to retry at all, or only retry a couple of times or…?

When a webhook has failed several times it might be preferable to disable and/or remove the webhook to prevent it consuming resources.

I haven't added any metadata to the webhook at the moment. It just does an empty POST request to the url(s) provided. This is enough for the EveryPolitician use-case so I thought it was best to offer nothing until we had more information on what people want from webhooks. ([Requestbin example of what's delivered currently](http://requestb.in/vgo2f6vg?inspect#w5dlxs))

The interface for adding webhooks is very minimal, it would be good to do something a bit fancier in the future, at least allow people to test webhooks and see what the last response status code was for example. Perhaps this would be better on its own page rather than cluttering up the settings page further? I quite like the way https://libraries.io does its webhook settings:

![screen shot 2016-01-26 at 10 47 03](https://cloud.githubusercontent.com/assets/22996/12578649/2ab93800-c41a-11e5-9c58-4a733b6767bd.png)


I obviously need to write some tests/docs for this if it seems like a reasonable approach :grimacing: 

Fixes #915 