### PR TITLE
Slightly improve webhooks settings helper text

### DIFF
--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -23,7 +23,7 @@
 
   %h3 Webhooks
   %p
-    We’ll make an HTTP POST request to each webhook URL every time this scraper finishes a run.
+    We’ll make an HTTP POST request to each webhook URL every time this scraper finishes running.
     = link_to 'Read documentation', webhooks_documentation_index_path
   .row
     .col-sm-3

--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -23,7 +23,7 @@
 
   %h3 Webhooks
   %p
-    We'll make an HTTP POST request to each webhook url every time this scraper finishes a run.
+    We’ll make an HTTP POST request to each webhook url every time this scraper finishes a run.
     = link_to 'Read documentation', webhooks_documentation_index_path
   .row
     .col-sm-3

--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -23,7 +23,7 @@
 
   %h3 Webhooks
   %p
-    We’ll make an HTTP POST request to each webhook url every time this scraper finishes a run.
+    We’ll make an HTTP POST request to each webhook URL every time this scraper finishes a run.
     = link_to 'Read documentation', webhooks_documentation_index_path
   .row
     .col-sm-3

--- a/app/views/scrapers/_settings.html.haml
+++ b/app/views/scrapers/_settings.html.haml
@@ -23,7 +23,7 @@
 
   %h3 Webhooks
   %p
-    We'll make an HTTP POST request to each webhook url whenever this scraper finishes running.
+    We'll make an HTTP POST request to each webhook url every time this scraper finishes a run.
     = link_to 'Read documentation', webhooks_documentation_index_path
   .row
     .col-sm-3


### PR DESCRIPTION
This is a small improvement to make the webhooks settings helper text a little clearer.

It's currently:

> We'll make an HTTP POST request to each webhook url whenever this scraper finishes running.

The wording “whenever this scraper finishes running”, uses longer, ambiguous words and could mean “when this scraper finally finishes running”. If you have a prior knowledge of morph.io you can logically interpret the intended meaning, but there is no need for us to require this knowledge.

These commits change it to:

> We’ll make an HTTP POST request to each webhook url every time this scraper finishes a run.

This is more specific and uses simpler, unambiguous words, so people can get all the knowledge they need directly from the text.

![screen shot 2016-02-23 at 12 00 19 pm](https://cloud.githubusercontent.com/assets/1239550/13238224/8db7f0ec-da25-11e5-87c3-9d2f5fed38df.png)