### PR TITLE
Make webhooks documentation clearer and more helpful

### DIFF
--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -3,7 +3,7 @@
 
   You can use webhooks to trigger actions in external services
   every time one of your scrapers finish a run.
-  You can trigger all kind of actions:
+  You can trigger all kind of fun actions:
   send emails when a scraper is finished;
   immediately pull fresh data from a scraper’s API;
   or run realtime analysis—anything you like really.

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -18,9 +18,9 @@
   ## Payloads
 
   Webhooks currently just make an empty HTTP POST request
-  to the specified url.
+  to the specified URL.
   If you'd like the webhooks to have some state
-  you'll need to put that state in the webhook url,
+  you'll need to put that state in the webhook URL,
   either as the path or as GET parameters.
   If there's something specific you'd like included in the webhook payload
   then please [ask a question on our help forum](https://help.morph.io/).

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -18,7 +18,7 @@
   ## Payloads
 
   We currently just make an empty HTTP POST request
-  to the specified webhook URL.
+  to your specified webhook URL.
   If you'd like the webhooks to have some state
   you'll need to put that state in the webhook URL,
   either as the path or as GET parameters.

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -18,7 +18,7 @@
   ## Payloads
 
   We currently just make an empty HTTP POST request
-  to your specified webhook URL.
+  to your specified webhook URLs.
   If you'd like the webhooks to have some state
   you'll need to put that state in the webhook URL,
   either as the path or as GET parameters.

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -19,7 +19,7 @@
 
   We currently just make an empty HTTP POST request
   to your specified webhook URLs.
-  You can pass information through the request
+  You can send information through the request
   by putting it in the webhook URL,
   either as the path or as GET parameters.
   If there’s something specific you’d like included in the webhook payload

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -2,7 +2,7 @@
   # Webhooks
 
   You can use webhooks to trigger actions in external services
-  every time one of your scrapers finish a run.
+  every time one of your scrapers finishes a run.
   You can trigger all kind of fun actions:
   send emails when a scraper is finished;
   immediately pull fresh data from a scraper’s API;

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -11,7 +11,8 @@
   Add *webhook URLs* under the **Webhooks heading
   on your scraper’s Settings page**.
   Every time your scraper finishes a run
-  we’ll make an HTTP POST request to each URL you’ve added.
+  we’ll make an [HTTP POST request](https://en.wikipedia.org/wiki/POST_(HTTP))
+  to each URL you’ve added.
   Use this request to trigger your custom code.
 
   ## Payloads

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -19,8 +19,8 @@
 
   We currently just make an empty HTTP POST request
   to your specified webhook URLs.
-  If you’d like the webhooks to have some state
-  you’ll need to put that state in the webhook URL,
+  If you’d like to pass some information through the request
+  you’ll need to put it in the webhook URL,
   either as the path or as GET parameters.
   If there’s something specific you’d like included in the webhook payload
   then please [ask a question on our help forum](https://help.morph.io/).

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -6,7 +6,7 @@
   You can trigger all kind of fun actions:
   send emails when a scraper is finished;
   immediately pull fresh data from a scraper’s API;
-  or run realtime analysis—anything you like really.
+  or run realtime analysis—anything you like.
 
   Add *webhook URLs* under the **Webhooks heading
   on your scraper’s Settings page**.

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -17,10 +17,12 @@
 
   ## Payloads
 
-  Webhooks currently just make an empty HTTP POST request to the specified url.
-  If you'd like the webhooks to have some state you'll need to put that state in
-  the webhook url, either as the path or as GET parameters. If there's something
-  specific you'd like included in the webhook payload then please
-  [ask a question on our help forum](https://help.morph.io/).
+  Webhooks currently just make an empty HTTP POST request
+  to the specified url.
+  If you'd like the webhooks to have some state
+  you'll need to put that state in the webhook url,
+  either as the path or as GET parameters.
+  If there's something specific you'd like included in the webhook payload
+  then please [ask a question on our help forum](https://help.morph.io/).
 
 

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -19,10 +19,10 @@
 
   We currently just make an empty HTTP POST request
   to your specified webhook URLs.
-  If you'd like the webhooks to have some state
-  you'll need to put that state in the webhook URL,
+  If you’d like the webhooks to have some state
+  you’ll need to put that state in the webhook URL,
   either as the path or as GET parameters.
-  If there's something specific you'd like included in the webhook payload
+  If there’s something specific you’d like included in the webhook payload
   then please [ask a question on our help forum](https://help.morph.io/).
 
 

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -19,8 +19,8 @@
 
   We currently just make an empty HTTP POST request
   to your specified webhook URLs.
-  If you’d like to pass some information through the request
-  you’ll need to put it in the webhook URL,
+  You can pass information through the request
+  by putting it in the webhook URL,
   either as the path or as GET parameters.
   If there’s something specific you’d like included in the webhook payload
   then please [ask a question on our help forum](https://help.morph.io/).

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -1,14 +1,18 @@
 :markdown
   # Webhooks
 
-  Webhooks allow you to run custom code when one of your scrapers has finished
-  running on morph.io. When a webhook is triggered, we'll send a HTTP POST
-  request to the webhook's configured URL. Webhooks can be used to transform
-  data into different formats, send out notifications, update an archive, or
-  even run some realtime analysis.
+  You can use webhooks to trigger actions in external services
+  every time one of your scrapers finish a run.
+  You can use this to do all kind of things:
+  send emails when a scraper is finished;
+  immediately pull fresh data from a scraper’s API;
+  or run realtime analysis—anything you like really.
 
-  Webhooks can be installed on any of your scrapers. Once installed, they will
-  be triggered each time that scraper finishes running.
+  Add *webhook URLs* under the **Webhooks heading
+  on your scraper’s Settings page**.
+  Every time your scraper finishes a run
+  we’ll make an HTTP POST request to each URL you’ve added.
+  Use this request to trigger your custom code.
 
   ## Payloads
 

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -17,8 +17,8 @@
 
   ## Payloads
 
-  Webhooks currently just make an empty HTTP POST request
-  to the specified URL.
+  We currently just make an empty HTTP POST request
+  to the specified webhook URL.
   If you'd like the webhooks to have some state
   you'll need to put that state in the webhook URL,
   either as the path or as GET parameters.

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -18,7 +18,9 @@
   ## Payloads
 
   We currently just make an empty HTTP POST request
-  to your specified webhook URLs.
+  to your specified webhook URLs;
+  no information about the scraper run
+  is added as a payload.
   You can send information through the request
   by putting it in the webhook URL,
   either as the path or as GET parameters.

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -3,7 +3,7 @@
 
   You can use webhooks to trigger actions in external services
   every time one of your scrapers finish a run.
-  You can use this to do all kind of things:
+  You can trigger all kind of actions:
   send emails when a scraper is finished;
   immediately pull fresh data from a scraper’s API;
   or run realtime analysis—anything you like really.


### PR DESCRIPTION
Currently the [Webhooks documentation](https://morph.io/documentation/webhooks) is confusing, especially for new users and people just learning about these kinds of technologies (see https://github.com/openaustralia/morph/issues/957).

I've tried to make it more clearer, friendlier and more focused on the benefit to people using more direct language, removing jargon, adding more concrete examples and telling people that they control this stuff from the settings page. I've also formatted this text for a line for each main point, which makes diffs much more precise and I find it really helpful to write interface text in this format.

I did a very rough test of this with a developer whose done a bit of scraping, but is new to this kinda stuff. They found said they understood how and why they might use this better with the new text. They particularly liked the examples and the description of where to control these on the scraper settings page.

I'm a bit unsure about the Payloads section. In https://github.com/openaustralia/morph/commit/c891f6a409bb9c6e884599fe6a31e1ac40aa9bd5 I've removed the term 'state' with information, as it seemed like jargon to me. Is this still accurate @chrismytton ?

I think it would also be helpful to add an example here of a webhook URL you might add with something in the path or query string. Do you have an example we could add @chrismytton ?

@chrismytton could you do a quick review of this since you made this great feature? :star2: :star2:

## Before

> # Webhooks
>
> Webhooks allow you to run custom code when one of your scrapers has finished running on morph.io. When a webhook is triggered, we'll send a HTTP POST request to the webhook's configured URL. Webhooks can be used to transform data into different formats, send out notifications, update an archive, or even run some realtime analysis.
> 
> Webhooks can be installed on any of your scrapers. Once installed, they will be triggered each time that scraper finishes running.
> 
> ## Payloads
>
> Webhooks currently just make an empty HTTP POST request to the specified url. If you'd like the webhooks to have some state you'll need to put that state in the webhook url, either as the path or as GET parameters. If there's something specific you'd like included in the webhook payload then please ask a question on our help forum.

## After

> # Webhooks
> 
> You can use webhooks to trigger actions in external services every time one of your scrapers finishes a run. You can trigger all kind of fun actions: send emails when a scraper is finished; immediately pull fresh data from a scraper’s API; or run realtime analysis—anything you like.
> 
> Add webhook URLs under the Webhooks heading on your scraper’s Settings page. Every time your scraper finishes a run we’ll make an HTTP POST request to each URL you’ve added. Use this request to trigger your custom code.
> 
> ## Payloads
> 
> We currently just make an empty HTTP POST request to your specified webhook URLs; no information about the scraper run is added as a payload. You can send information through the request by putting it in the webhook URL, either as the path or as GET parameters. If there’s something specific you’d like included in the webhook payload then please ask a question on our help forum.

![screen shot 2016-02-26 at 11 45 44 am](https://cloud.githubusercontent.com/assets/1239550/13339672/83878a5a-dc7e-11e5-9607-808c9196f834.png)