### PR TITLE
Committing /tmp/pids to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,15 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
-# Ignore all logfiles and tempfiles.
+# Ignore all logfiles and most tempfiles.
 /log/*.log
-/tmp
+/tmp/cache
+/tmp/miniprofiler
+/tmp/sessions
+/tmp/sockets
+
+# Ignore the PID tempfiles but not the folder that holds them.
+/tmp/pids/*.pid
 
 /.env
 /.env.local


### PR DESCRIPTION
Continue to git-ignore all logfiles and most tempfiles.

Continue git-ignoring the PID tempfiles but not the PID folder, which Sidekiq sometimes expects to already exist.

Closes #967 