### PR TITLE
Randomise list of heroes; closes #893

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 /tmp/sessions
 /tmp/sockets
 
-# Ignore the PID tempfiles but not the folder that holds them.
+# Ignore the PID tempfiles but not PID folder that holds them.
 /tmp/pids/*.pid
 
 /.env

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -18,7 +18,7 @@ class Owner < ActiveRecord::Base
   serialize :feature_switches
 
   # Supporters that are on a particular plan
-  scope :supporters, ->(plan) { where(stripe_plan_id: plan.stripe_plan_id).order(order: "RAND()") }
+  scope :supporters, ->(plan) { where(stripe_plan_id: plan.stripe_plan_id).order("RAND()") }
 
   scope :all_supporters, -> { where.not(stripe_plan_id: "") }
 

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -18,7 +18,7 @@ class Owner < ActiveRecord::Base
   serialize :feature_switches
 
   # Supporters that are on a particular plan
-  scope :supporters, ->(plan) { where(stripe_plan_id: plan.stripe_plan_id) }
+  scope :supporters, ->(plan) { where(stripe_plan_id: plan.stripe_plan_id).order(order: "RAND()") }
 
   scope :all_supporters, -> { where.not(stripe_plan_id: "") }
 


### PR DESCRIPTION
This pull request randomises the Owner.supports(plan) scope so heroes are listed in random order. Note, this change uses an MySQL only option, but as Morph.io seems pretty closely bound with MySQL, that seemed fine.

Note: also loops in a minor change I made to the wording of the .gitignore file before I made a branch for this feature.

closes #893