### PR TITLE
Upgrade excon gem to fix problem when accessing docker 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,11 @@ gem "grit"
 # version 1.20.0 of the docker-api gem is causing the compile step in buildstep
 # to not get cached
 gem 'docker-api', "< 1.20.0", :require => 'docker'
+# excon is only needed by docker-api. There is no need to include it here
+# other than to fix the version of excon to 0.46.0. We should be able to remove
+# this when we upgrade the docker-api gem
+# See https://github.com/swipely/docker-api/tree/c1308961a5d799a62ed906df8206acd1ac6b4b2c#known-issues
+gem "excon", "0.46.0"
 gem "sidekiq"
 gem 'sidekiq-limit_fetch'
 gem 'sidekiq-unique-jobs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     eventmachine (1.0.7)
-    excon (0.45.1)
+    excon (0.46.0)
     execjs (2.4.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -530,6 +530,7 @@ DEPENDENCIES
   devise
   docker-api (< 1.20.0)
   dotenv-rails
+  excon (= 0.46.0)
   factory_girl_rails (~> 4.0)
   faraday
   faye
@@ -594,4 +595,4 @@ DEPENDENCIES
   zeroclipboard-rails
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
The problem only occurs when accessing docker through a local socket. Before on OS X I was using a network connection to docker so wasn't seeing the issue. This does the minimal upgrade to fix the problem.

if we were to upgrade to the absolute latest version of `excon` that would cause problems with the current version of `docker-api`. So, best to seperate these changes and do the smallest thing now