### PR TITLE
Rake task to remove log lines for old runs (not the most recent)

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -123,6 +123,18 @@ namespace :app do
     end
   end
 
+  desc "Remove log lines for old runs (not the latest ones)"
+  task clean_up_old_log_lines: :environment do
+    Scraper.all.each do |scraper|
+      puts "Removing old logs for #{scraper.full_name}..."
+      runs = scraper.runs.order(queued_at: :desc)
+      # Remove the most recently run from the list
+      runs = runs[1..-1]
+      # Now remove the logs connected to those runs
+      LogLine.delete_all(run: runs)
+    end
+  end
+
   def confirm(message)
     STDOUT.puts "#{message} (y/n)"
     STDIN.gets.strip == 'y'


### PR DESCRIPTION
This fixes #999.

I've tested it locally on my development box that's seeded with old production data and it looks to work fine. I've checked a few scrapers and they all have their logs visible in the UI. I've also done a count of the log lines and they're massively reduced in number after running this.

I'd like to run this in production as soon as possible.