### PR TITLE
Limit log lines to 10,000 lines

### DIFF
--- a/app/views/documentation/_limits.md
+++ b/app/views/documentation/_limits.md
@@ -14,6 +14,15 @@ If you're hitting up against these hard limits and still want to use morph.io
 please [do get in touch](mailto:contact@oaf.org.au) and let us know and we'll
 see what we can do to help.
 
+There's also a soft limit:
+
+* max <%= number_with_delimiter Morph::Runner.default_max_lines %> lines of log output
+
+If a scraper generates more than <%= number_with_delimiter Morph::Runner.default_max_lines %> lines
+of log output the scraper will continue running uninterrupted. You just won't
+see any more output than that. To avoid this happening simply print less stuff
+to the screen.
+
 Note that we are keeping track of the amount of cpu time (and a whole bunch of
 other metrics) that you and your scrapers are using. So, if we do find that you
 are using too much (and no we don't know what that is right now) we reserve the

--- a/app/views/documentation/_limits.md
+++ b/app/views/documentation/_limits.md
@@ -4,7 +4,7 @@ this.
 However, we do impose a couple of hard limits on running scrapers so they don't
 take up too many resources
 
-* max 512 MB memory
+* max <%= number_to_human_size Morph::DockerRunner.memory_limit %> memory
 * max 24 hours run time for a single run
 
 If a scraper runs out of memory or runs too long it will get killed

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -20,8 +20,8 @@ module Morph
       go_with_logging
     end
 
-    def go_with_logging
-      go do |timestamp, s, c|
+    def go_with_logging(max_lines = nil)
+      go(max_lines) do |timestamp, s, c|
         log(timestamp, s, c)
         yield timestamp, s, c if block_given?
       end
@@ -34,7 +34,7 @@ module Morph
       sync_new line, scope: run unless Rails.env.test?
     end
 
-    def go
+    def go(max_lines = nil)
       # If container already exists we just attach to it
       c = container_for_run
       if c.nil?
@@ -53,8 +53,10 @@ module Morph
         # to compensate for this and ensure that the "since" time occurs
         # slightly after the true time.
         since += 1e-6 if since
+        # Deal with situation of since set in calculation of max_lines
+        max_lines -= run.log_lines.where(stream: [:stdout, :stderr]).count if max_lines
       end
-      attach_to_run_and_finish(c, since) do |timestamp, s, c|
+      attach_to_run_and_finish(c, since, max_lines) do |timestamp, s, c|
         yield timestamp, s, c
       end
     end
@@ -99,13 +101,13 @@ module Morph
       c
     end
 
-    def attach_to_run_and_finish(c, since)
+    def attach_to_run_and_finish(c, since, max_lines = nil)
       if c.nil?
         # TODO: Return the status for a compile error
         result = Morph::RunResult.new(255, {}, {})
       else
         result = Morph::DockerRunner.attach_to_run_and_finish(
-          c, ['data.sqlite'], since) do |timestamp, s, c|
+          c, ['data.sqlite'], since, max_lines) do |timestamp, s, c|
           yield(timestamp, s, c)
         end
       end

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -9,6 +9,11 @@ module Morph
       @run = run
     end
 
+    # TODO Move this to a configuration somewhere
+    def self.default_max_lines
+      10000
+    end
+
     # The main section of the scraper running that is run in the background
     def synch_and_go!
       # If this run belongs to a scraper that has just been deleted
@@ -17,7 +22,7 @@ module Morph
       return if run.scraper.nil? || run.finished?
 
       run.scraper.synchronise_repo
-      go_with_logging
+      go_with_logging(Runner.default_max_lines)
     end
 
     def go_with_logging(max_lines = nil)

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -1,6 +1,8 @@
 namespace :app do
   desc 'Stop long running scraper containers (should be run from cron job)'
   task stop_long_running_scrapers: :environment do
+    # TODO Move this a configuration. Also, it's referenced in the documentation
+    # So, the two should really be automatically in sync
     max_duration = 1.day
 
     # Let's start by just showing running containers

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -170,6 +170,24 @@ describe Morph::DockerRunner do
       end
       expect(logs).to eq ["Started!\n", "1...\n", "2...\n", "3...\n", "4...\n", "5...\n", "6...\n", "7...\n", "8...\n", "9...\n", "10...\n", "Finished!\n"]
     end
+
+    it 'should be able to limit the amount of log output' do
+      copy_test_scraper('stream_output_ruby')
+
+      c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
+      logs = []
+      Morph::DockerRunner.attach_to_run_and_finish(c, [], nil, 5) do |timestamp, s, c|
+        logs << [s, c]
+      end
+      expect(logs).to eq [
+        [:stdout, "Started!\n"],
+        [:stdout, "1...\n"],
+        [:stdout, "2...\n"],
+        [:stdout, "3...\n"],
+        [:stdout, "4...\n"],
+        [:internalerr, "\nToo many lines of output! Your scraper will continue uninterrupted. There will just be no further output displayed\n"]
+      ]
+    end
   end
 
   skip 'should cache the compile' do


### PR DESCRIPTION
This PR also adds some documentation and amazingly more tests which also makes sure that the counting of log lines can handle restarts of the logging process.

This fixes #919 