### PR TITLE
Fix referential integrity part 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem "stripe"
 gem 'haml-coderay'
 gem 'd3-rails'
 gem "validate_url"
+gem 'ruby-progressbar'
 
 group :production do
   gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,6 +421,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-progressbar (1.8.1)
     ruby_dep (1.3.1)
     ruby_parser (3.8.2)
       sexp_processor (~> 4.1)
@@ -583,6 +584,7 @@ DEPENDENCIES
   rest-client
   rspec-activemodel-mocks
   rspec-rails
+  ruby-progressbar
   sass-rails
   sdoc
   searchkick

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -2,9 +2,9 @@
 class Run < ActiveRecord::Base
   belongs_to :owner
   belongs_to :scraper, inverse_of: :runs, touch: true
-  has_many :log_lines
-  has_one :metric
-  has_many :connection_logs
+  has_many :log_lines, dependent: :delete_all
+  has_one :metric, dependent: :delete
+  has_many :connection_logs, dependent: :delete_all
   has_many :domains, -> { distinct }, through: :connection_logs
 
   scope :finished_successfully, -> { where(status_code: 0) }

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -14,23 +14,22 @@ class Scraper < ActiveRecord::Base
   belongs_to :owner, inverse_of: :scrapers
   belongs_to :forked_by, class_name: 'User'
 
-  has_many :runs, inverse_of: :scraper
+  has_many :runs, inverse_of: :scraper, dependent: :destroy
   has_many :metrics, through: :runs
   has_many :contributors, through: :contributions, source: :user
-  has_many :contributions
-  has_many :watches, class_name: 'Alert', foreign_key: :watch_id
+  has_many :contributions, dependent: :delete_all
+  has_many :watches, class_name: 'Alert', foreign_key: :watch_id, dependent: :delete_all
   has_many :watchers, through: :watches, source: :user
-  belongs_to :create_scraper_progress
-  has_many :variables
+  belongs_to :create_scraper_progress, dependent: :delete
+  has_many :variables, dependent: :delete_all
   accepts_nested_attributes_for :variables, allow_destroy: true
-  has_many :webhooks
+  has_many :webhooks, dependent: :destroy
   accepts_nested_attributes_for :webhooks, allow_destroy: true
   validates_associated :variables
   delegate :sqlite_total_rows, to: :database
-
   has_one :last_run, -> { order 'queued_at DESC' }, class_name: 'Run'
 
-  has_many :api_queries
+  has_many :api_queries, dependent: :delete_all
 
   validates :name, presence: true, format: {
     with: /\A[a-zA-Z0-9_-]+\z/,

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -1,5 +1,6 @@
 # A secret environment variable and its value that can be passed to a scraper
 class Variable < ActiveRecord::Base
+  belongs_to :scraper
   validates :name, format: {
     with: /\AMORPH_[A-Z0-9_]+\z/,
     message: 'should look something like MORPH_SEAGULL'

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,6 +1,6 @@
 class Webhook < ActiveRecord::Base
   belongs_to :scraper
-  has_many :deliveries, class_name: WebhookDelivery
+  has_many :deliveries, class_name: WebhookDelivery, dependent: :delete_all
   validates :url, presence: true, url: true, uniqueness: {scope: :scraper, message: "already another webhook with this URL"}
 
   def last_delivery

--- a/lib/tasks/emergency.rake
+++ b/lib/tasks/emergency.rake
@@ -40,5 +40,50 @@ namespace :app do
         end
       end
     end
+
+    # See https://github.com/openaustralia/morph/issues/1038
+    desc "Removed records from other tables associated with deleted scrapers"
+    task fix_referential_integrity: :environment do
+      def destroy_by_id(model, ids)
+        progressbar = ProgressBar.create(title: model.name.pluralize, total: ids.count, format: "%t: |%B| %E")
+        ids.each do |id|
+          model.find(id).destroy
+          progressbar.increment
+        end
+      end
+
+      ids = Alert.connection.select_all("SELECT id FROM alerts WHERE watch_type = 'Scraper' AND watch_id NOT IN (SELECT id FROM scrapers)").map{|id| id["id"]}
+      destroy_by_id(Alert, ids)
+
+      ids = ApiQuery.connection.select_all("SELECT id FROM api_queries WHERE scraper_id NOT IN (SELECT id FROM scrapers)").map{|id| id["id"]}
+      destroy_by_id(ApiQuery, ids)
+
+      ids = Contribution.connection.select_all("SELECT id FROM contributions WHERE scraper_id NOT IN (SELECT id FROM scrapers)").map{|id| id["id"]}
+      destroy_by_id(Contribution, ids)
+
+      ids = Run.connection.select_all("SELECT id FROM runs WHERE scraper_id NOT IN (SELECT id FROM scrapers)").map{|id| id["id"]}
+      destroy_by_id(Run, ids)
+
+      ids = Variable.connection.select_all("SELECT id FROM variables WHERE scraper_id NOT IN (SELECT id FROM scrapers)").map{|id| id["id"]}
+      destroy_by_id(Variable, ids)
+
+      ids = Webhook.connection.select_all("SELECT id FROM webhooks WHERE scraper_id NOT IN (SELECT id FROM scrapers)").map{|id| id["id"]}
+      destroy_by_id(Webhook, ids)
+
+      ids = ConnectionLog.connection.select_all("SELECT id FROM connection_logs WHERE run_id NOT IN (SELECT id FROM runs)").map{|id| id["id"]}
+      ConnectionLog.where(id: ids).delete_all
+
+      ids = LogLine.connection.select_all("SELECT id FROM log_lines WHERE run_id NOT IN (SELECT id FROM runs)").map{|id| id["id"]}
+      LogLine.where(id: ids).delete_all
+
+      ids = Metric.connection.select_all("SELECT id FROM metrics WHERE run_id NOT IN (SELECT id FROM runs)").map{|id| id["id"]}
+      Metric.where(id: ids).delete_all
+
+      ids = WebhookDelivery.connection.select_all("SELECT id FROM webhook_deliveries WHERE run_id NOT IN (SELECT id FROM runs)").map{|id| id["id"]}
+      WebhookDelivery.where(id: ids).delete_all
+
+      ids = WebhookDelivery.connection.select_all("SELECT id FROM webhook_deliveries WHERE webhook_id NOT IN (SELECT id FROM webhooks)").map{|id| id["id"]}
+      WebhookDelivery.where(id: ids).delete_all
+    end
   end
 end


### PR DESCRIPTION
When destroying a scraper will now destroy the associated bits and pieces as well. This PR also adds a new rake task to clean up any records associated with deleted scrapers.

There is a second associated PR which adds foreign key constraints to the database once everything is in a better state.

But before touching that we should get the changes here deployed and the rake task run on the production server