### PR TITLE
Only redirect traffic from morph docker containers to mitmproxy

### DIFF
--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -14,6 +14,9 @@ module Morph
       'package.json'
     ]
     BUILDSTEP_IMAGE = 'openaustralia/buildstep'
+    DOCKER_NETWORK = 'morph'
+    DOCKER_BRIDGE = 'morph'
+    DOCKER_NETWORK_SUBNET = '192.168.0.0/16'
 
     def self.time_file
       '/app/time.output'
@@ -41,6 +44,26 @@ module Morph
       # If something went wrong during the compile and it couldn't finish
       return [nil, nil] if i3.nil?
 
+      # Before we create a container we need to make sure that there is a
+      # special network there for it to be put into
+      begin
+        Docker::Network.get(DOCKER_NETWORK)
+        exists = true
+      rescue Docker::Error::NotFoundError
+        exists = false
+      end
+      Docker::Network.create(DOCKER_NETWORK, {
+          'Options' => {
+            'com.docker.network.bridge.name' => DOCKER_BRIDGE,
+            'com.docker.network.bridge.enable_icc' => 'false'
+          },
+          'IPAM' => {
+            'Config' => [{
+                'Subnet' => DOCKER_NETWORK_SUBNET
+            }]
+          }
+        }) unless exists
+
       command = Morph::TimeCommand.command(['/start', 'scraper'], time_file)
 
       # TODO: Also copy back time output file and the sqlite journal file
@@ -56,7 +79,11 @@ module Morph
           {
             'REQUESTS_CA_BUNDLE' => '/etc/ssl/certs/ca-certificates.crt'
           }.merge(env_variables).map { |k, v| "#{k}=#{v}" },
-        'Labels' => container_labels
+        'Labels' => container_labels,
+        'HostConfig' => {
+          # Attach this container to our special network morph
+          'NetworkMode' => DOCKER_NETWORK
+        }
       }
 
       c = Docker::Container.create(container_options)

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -179,5 +179,33 @@ module Morph
       end
       File.delete(tar_file)
     end
+
+    def self.surpress_warnings(&block)
+      verbosity = $VERBOSE
+      $VERBOSE = nil
+      result = block.call
+      $VERBOSE = verbosity
+      result
+    end
+
+    # Fools the docker-api gem into using a later version of the api
+    # Use with caution and selectively
+    def self.run_with_later_version_of_docker_api(&block)
+      version = Docker::API_VERSION
+      surpress_warnings do
+        Docker.const_set(:API_VERSION, "1.24")
+      end
+      result = block.call
+      surpress_warnings do
+        Docker.const_set(:API_VERSION, version)
+      end
+      result
+    end
+
+    def self.ip_address_of_container(c)
+      Morph::DockerUtils.run_with_later_version_of_docker_api do
+        c.json['NetworkSettings']['Networks'].values.first['IPAddress']
+      end
+    end
   end
 end

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -99,7 +99,7 @@ module Morph
       end
 
       # Record ip address of running container
-      ip_address = c.json['NetworkSettings']['IPAddress'] if c
+      ip_address = Morph::DockerUtils.ip_address_of_container(c) if c
       # The image id here is a short one. Not sure why.
       # TODO: Investigate
       docker_image = image.id if image

--- a/provisioning/roles/morph-app/files/iptables-morph-add
+++ b/provisioning/roles/morph-app/files/iptables-morph-add
@@ -21,6 +21,11 @@ iptables -A INPUT -i eth0 -j DROP
 iptables -t nat -A PREROUTING -i docker0 -p tcp --dport 80 -j REDIRECT --to-ports 8080
 iptables -t nat -A PREROUTING -i docker0 -p tcp --dport 443 -j REDIRECT --to-ports 8080
 
+# Redirect HTTP and HTTPS to mitmproxy (for new morph network)
+# Note that this will still work even if the morph interface doesn't yet exist
+iptables -t nat -A PREROUTING -i morph -p tcp --dport 80 -j REDIRECT --to-ports 8080
+iptables -t nat -A PREROUTING -i morph -p tcp --dport 443 -j REDIRECT --to-ports 8080
+
 # Allow DNS, HTTP and HTTPS
 #iptables -A DOCKER -p tcp --sport domain -j ACCEPT
 #iptables -A DOCKER -p udp --sport domain -j ACCEPT

--- a/provisioning/roles/morph-app/files/iptables-morph-remove
+++ b/provisioning/roles/morph-app/files/iptables-morph-remove
@@ -20,6 +20,9 @@ iptables -D INPUT -i eth0 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -t nat -D PREROUTING -i docker0 -p tcp --dport 80 -j REDIRECT --to-ports 8080
 iptables -t nat -D PREROUTING -i docker0 -p tcp --dport 443 -j REDIRECT --to-ports 8080
 
+iptables -t nat -D PREROUTING -i morph -p tcp --dport 80 -j REDIRECT --to-ports 8080
+iptables -t nat -D PREROUTING -i morph -p tcp --dport 443 -j REDIRECT --to-ports 8080
+
 #iptables -D DOCKER -p tcp --sport domain -j ACCEPT
 #iptables -D DOCKER -p udp --sport domain -j ACCEPT
 #iptables -D DOCKER -p tcp --sport http -j ACCEPT

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -157,11 +157,12 @@ describe Morph::DockerRunner do
 
       ip_address = nil
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
+      ip_address = Morph::DockerUtils.ip_address_of_container(c)
       result = Morph::DockerRunner.attach_to_run_and_finish(
         c, ['ip_address']) {}
       expect(result.status_code).to eq 0
       # Check that ip address lies in the expected subnet
-      expect(result.files['ip_address'].split('.')[0..1]).to eq ["192", "168"]
+      expect(ip_address).to eq result.files['ip_address']
     end
 
     it 'should return a non-zero error code if the scraper fails' do

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -47,6 +47,20 @@ describe Morph::DockerRunner do
       expect(logs).to eq [[:stdout, "Hello world!\n"]]
     end
 
+    it "should attach the container to a special morph-only docker network" do
+      copy_test_scraper('hello_world_js')
+
+      c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
+      expect(c.json['HostConfig']['NetworkMode']).to eq 'morph'
+      # Check that the network has some things set
+      network_info = Docker::Network.get('morph').info
+      expect(network_info['Options']['com.docker.network.bridge.name']).to eq "morph"
+      expect(network_info['Options']["com.docker.network.bridge.enable_icc"]).to eq 'false'
+      expect(network_info['IPAM']['Config'].first['Subnet']).to eq '192.168.0.0/16'
+      c.kill
+      c.delete
+    end
+
     it 'should be able to run hello world from a sub-directory' do
       copy_test_scraper('hello_world_subdirectory_js')
 
@@ -143,12 +157,11 @@ describe Morph::DockerRunner do
 
       ip_address = nil
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
-      ip_address = c.json['NetworkSettings']['IPAddress']
       result = Morph::DockerRunner.attach_to_run_and_finish(
         c, ['ip_address']) {}
       expect(result.status_code).to eq 0
-      # These logs will actually be different if the compile isn't cached
-      expect(ip_address).to eq result.files['ip_address']
+      # Check that ip address lies in the expected subnet
+      expect(result.files['ip_address'].split('.')[0..1]).to eq ["192", "168"]
     end
 
     it 'should return a non-zero error code if the scraper fails' do

--- a/spec/lib/morph/runner_spec.rb
+++ b/spec/lib/morph/runner_spec.rb
@@ -173,6 +173,19 @@ describe Morph::Runner do
       ]
     end
 
+    it 'should record the container ip address in the run' do
+      owner = User.create(nickname: 'mlandauer')
+      run = Run.create(owner: owner)
+      FileUtils.rm_rf(run.data_path)
+      FileUtils.rm_rf(run.repo_path)
+      fill_scraper_for_run('save_to_database', run)
+      runner = Morph::Runner.new(run)
+      runner.go_with_logging {}
+      run.reload
+      subnet = run.ip_address.split('.')[0..1].join('.')
+      expect(subnet).to eq "192.168"
+    end
+
     it 'should be able to correctly limit the number of lines even after a restart' do
       owner = User.create(nickname: 'mlandauer')
       run = Run.create(owner: owner)


### PR DESCRIPTION
This creates a new docker network which is used to run scrapers in. This allows us more fine-grained control over the networking. Best of all we can create a special interface on the host machine 'morph' from which all traffic from scrapers will originate. Then, we can just redirect traffic from that interface to mitmproxy which fixes #523.

This pull request will redirect traffic from the "old" bridge0 network and the "new" morph network to mitmproxy which means that it can be deployed without breaking anything.

When everything is up and running and deployed then we can remove the iptables stuff to redirect the traffic from bridge0 to mitmproxy which will then have properly fixed #523.