### PR TITLE
Significantly reduce peak memory usage of sidekiq process

### DIFF
--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -155,6 +155,13 @@ module Morph
 
       # Grab the resulting files
       data = Morph::DockerUtils.copy_files(container, files + [time_file])
+      data.keys.each do |path|
+        tmp = data[path]
+        if tmp
+          data[path] = tmp.read
+          tmp.close!
+        end
+      end
 
       # Clean up after ourselves
       container.delete

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -111,25 +111,6 @@ module Morph
     # time is non-inclusive so we shouldn't return the log line with that
     # exact timestamp, just ones after it.
     def self.attach_to_run_and_finish(container, files, since = nil,
-                                      max_lines = nil)
-
-      result1 = attach_to_run_and_finish2(container, files, since, max_lines) do |timestamp, s, c|
-        yield timestamp, s, c
-      end
-
-      files = result1.files
-      files.keys.each do |path|
-        tmp = files[path]
-        if tmp
-          files[path] = tmp.read
-          tmp.close!
-        end
-      end
-
-      Morph::RunResult.new(result1.status_code, files, result1.time_params)
-    end
-
-    def self.attach_to_run_and_finish2(container, files, since = nil,
                                        max_lines = nil)
       params = { stdout: true, stderr: true, follow: true, timestamps: true }
       params[:since] = since.to_f if since

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -82,21 +82,10 @@ module Morph
       end
     end
 
-    # Copy a single file from a container. Returns a string with the contents
-    # of the file. Obviously need to provide a filesystem path within the
-    # container
-    def self.copy_file(container, path)
-      tmp = copy_file2(container, path)
-      return nil if tmp.nil?
-      result = File.open(tmp.path, 'rb', &:read)
-      tmp.close!
-      result
-    end
-
     # Copy a single file from a container. Returns a temp file with the contents
     # of the file from the container. Obviously need to provide a filesystem
     # path within the container
-    def self.copy_file2(container, path)
+    def self.copy_file(container, path)
       # We're going to create a new connection to the same container
       # to avoid whatever connection settings are being used
       container2 = Docker::Container.get(container.id)
@@ -130,7 +119,13 @@ module Morph
     def self.copy_files(container, paths)
       data = {}
       paths.each do |path|
-        data[path] = Morph::DockerUtils.copy_file(container, path)
+        tmp = copy_file(container, path)
+        if tmp
+          data[path] = File.open(tmp.path, 'rb', &:read)
+          tmp.close!
+        else
+          data[path] = nil
+        end
       end
       data
     end

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -121,7 +121,7 @@ module Morph
       paths.each do |path|
         tmp = copy_file(container, path)
         if tmp
-          data[path] = File.open(tmp.path, 'rb', &:read)
+          data[path] = tmp.read
           tmp.close!
         else
           data[path] = nil

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -117,15 +117,26 @@ module Morph
 
     # Get a set of files from a container and return them as a hash
     def self.copy_files(container, paths)
-      data = {}
-      paths.each do |path|
-        tmp = copy_file(container, path)
+      data = copy_files2(container, paths)
+
+      data.keys.each do |path|
+        tmp = data[path]
         if tmp
           data[path] = tmp.read
           tmp.close!
         else
           data[path] = nil
         end
+      end
+      data
+    end
+
+    # Get a set of files from a container and return them as a hash of
+    # local temporary files
+    def self.copy_files2(container, paths)
+      data = {}
+      paths.each do |path|
+        data[path] = copy_file(container, path)
       end
       data
     end

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -86,6 +86,17 @@ module Morph
     # of the file. Obviously need to provide a filesystem path within the
     # container
     def self.copy_file(container, path)
+      tmp = copy_file2(container, path)
+      return nil if tmp.nil?
+      result = File.open(tmp.path, 'rb', &:read)
+      tmp.close!
+      result
+    end
+
+    # Copy a single file from a container. Returns a temp file with the contents
+    # of the file from the container. Obviously need to provide a filesystem
+    # path within the container
+    def self.copy_file2(container, path)
       # We're going to create a new connection to the same container
       # to avoid whatever connection settings are being used
       container2 = Docker::Container.get(container.id)
@@ -109,8 +120,10 @@ module Morph
         tmp.unlink
 
         path2 = File.join(dest, Pathname.new(path).basename.to_s)
-        File.open(path2, 'rb', &:read)
+        tmp = Tempfile.new('morph-file')
+        FileUtils.cp(path2, tmp.path)
       end
+      tmp
     end
 
     # Get a set of files from a container and return them as a hash

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -115,25 +115,9 @@ module Morph
       tmp
     end
 
-    # Get a set of files from a container and return them as a hash
-    def self.copy_files(container, paths)
-      data = copy_files2(container, paths)
-
-      data.keys.each do |path|
-        tmp = data[path]
-        if tmp
-          data[path] = tmp.read
-          tmp.close!
-        else
-          data[path] = nil
-        end
-      end
-      data
-    end
-
     # Get a set of files from a container and return them as a hash of
     # local temporary files
-    def self.copy_files2(container, paths)
+    def self.copy_files(container, paths)
       data = {}
       paths.each do |path|
         data[path] = copy_file(container, path)

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -123,6 +123,7 @@ module Morph
       # Only copy back database if it's there and has something in it
       if result.files && result.files['data.sqlite']
         Morph::Runner.copy_sqlite_db_back(run.data_path, result.files['data.sqlite'])
+        result.files['data.sqlite'].close!
       end
 
       # Now collect and save the metrics
@@ -188,16 +189,12 @@ module Morph
     end
 
     def self.copy_sqlite_db_back(data_path, sqlite_file)
-      # TODO NO READING OF FILES INTO MEMORY
-      sqlite_data = sqlite_file.read
-      sqlite_file.close!
-
       # Only overwrite the sqlite database if the container has one
-      if sqlite_data
+      if sqlite_file
         # First write to a temporary file with the new sqlite data
-        File.open(File.join(data_path, 'data.sqlite.new'), 'wb') do |f|
-          f << sqlite_data
-        end
+        # Copying across just in case temp directory and data_path directory
+        # not on the same filesystem (which would stop atomic rename from working)
+        FileUtils.cp(sqlite_file.path, File.join(data_path, 'data.sqlite.new'))
         # Then, rename the file to the "live" file overwriting the old data
         # This should happen atomically
         File.rename(File.join(data_path, 'data.sqlite.new'),

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -122,7 +122,7 @@ module Morph
 
       # Only copy back database if it's there and has something in it
       if result.files && result.files['data.sqlite']
-        Morph::Runner.copy_sqlite_db_back2(run.data_path, result.files['data.sqlite'])
+        Morph::Runner.copy_sqlite_db_back(run.data_path, result.files['data.sqlite'])
       end
 
       # Now collect and save the metrics
@@ -187,15 +187,11 @@ module Morph
       end
     end
 
-    def self.copy_sqlite_db_back2(data_path, sqlite_file)
+    def self.copy_sqlite_db_back(data_path, sqlite_file)
       # TODO NO READING OF FILES INTO MEMORY
       sqlite_data = sqlite_file.read
       sqlite_file.close!
 
-      copy_sqlite_db_back(data_path, sqlite_data)
-    end
-
-    def self.copy_sqlite_db_back(data_path, sqlite_data)
       # Only overwrite the sqlite database if the container has one
       if sqlite_data
         # First write to a temporary file with the new sqlite data

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -118,22 +118,11 @@ module Morph
         ) do |timestamp, s, c|
           yield(timestamp, s, c)
         end
-
-        files = result.files
-        files.keys.each do |path|
-          tmp = files[path]
-          if tmp
-            files[path] = tmp.read
-            tmp.close!
-          end
-        end
-
-        result = Morph::RunResult.new(result.status_code, files, result.time_params)
       end
 
       # Only copy back database if it's there and has something in it
-      if result.files && result.files.key?('data.sqlite')
-        Morph::Runner.copy_sqlite_db_back(run.data_path, result.files['data.sqlite'])
+      if result.files && result.files['data.sqlite']
+        Morph::Runner.copy_sqlite_db_back2(run.data_path, result.files['data.sqlite'])
       end
 
       # Now collect and save the metrics
@@ -196,6 +185,14 @@ module Morph
         # link on the container
         FileUtils.touch(File.join(dir, 'data.sqlite'))
       end
+    end
+
+    def self.copy_sqlite_db_back2(data_path, sqlite_file)
+      # TODO NO READING OF FILES INTO MEMORY
+      sqlite_data = sqlite_file.read
+      sqlite_file.close!
+
+      copy_sqlite_db_back(data_path, sqlite_data)
     end
 
     def self.copy_sqlite_db_back(data_path, sqlite_data)

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -118,6 +118,17 @@ module Morph
         ) do |timestamp, s, c|
           yield(timestamp, s, c)
         end
+
+        files = result.files
+        files.keys.each do |path|
+          tmp = files[path]
+          if tmp
+            files[path] = tmp.read
+            tmp.close!
+          end
+        end
+
+        result = Morph::RunResult.new(result.status_code, files, result.time_params)
       end
 
       # Only copy back database if it's there and has something in it

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -68,7 +68,7 @@ describe Morph::DockerRunner do
       end
 
       #report.pretty_print
-      expect(report.total_allocated_memsize).to be < 1_500_000
+      expect(report.total_allocated_memsize).to be < 2_000_000
       expect(report.total_retained_memsize < 15_000)
     end
 

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -41,7 +41,7 @@ describe Morph::DockerRunner do
 
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       logs = []
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(result.status_code).to eq 0
@@ -63,7 +63,7 @@ describe Morph::DockerRunner do
       report = MemoryProfiler.report do
         with_smaller_chunk_size do
           c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
-          Morph::DockerRunner.attach_to_run_and_finish2(c, []) {}
+          Morph::DockerRunner.attach_to_run_and_finish(c, []) {}
         end
       end
 
@@ -91,7 +91,7 @@ describe Morph::DockerRunner do
 
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       logs = []
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(result.status_code).to eq 0
@@ -104,7 +104,7 @@ describe Morph::DockerRunner do
       # Do the compile once to make sure the cache is primed
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       logs = []
-      # Clean up container because we're not calling attach_to_run_and_finish2
+      # Clean up container because we're not calling attach_to_run_and_finish
       # which normally does the cleanup
       c.kill
       c.delete
@@ -125,7 +125,7 @@ describe Morph::DockerRunner do
 
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       logs = []
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(result.status_code).to eq 0
@@ -140,7 +140,7 @@ describe Morph::DockerRunner do
       copy_test_scraper('write_to_file_ruby')
 
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
-      result = Morph::DockerRunner.attach_to_run_and_finish2(
+      result = Morph::DockerRunner.attach_to_run_and_finish(
         c, ['foo.txt', 'bar']) {}
       expect(result.status_code).to eq 0
       expect(result.files.keys).to eq(['foo.txt', 'bar'])
@@ -156,7 +156,7 @@ describe Morph::DockerRunner do
       logs = []
       c, _i3 = Morph::DockerRunner.compile_and_start_run(
         @dir, { 'AN_ENV_VARIABLE' => 'Hello world!' }, {}) {}
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(result.status_code).to eq 0
@@ -172,7 +172,7 @@ describe Morph::DockerRunner do
       c, _i3 = Morph::DockerRunner.compile_and_start_run(
         @dir, {}, {}) {}
       logs = []
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(result.status_code).to eq 0
@@ -185,7 +185,7 @@ describe Morph::DockerRunner do
       ip_address = nil
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       ip_address = Morph::DockerUtils.ip_address_of_container(c)
-      result = Morph::DockerRunner.attach_to_run_and_finish2(
+      result = Morph::DockerRunner.attach_to_run_and_finish(
         c, ['ip_address']) {}
       expect(result.status_code).to eq 0
       # Check that ip address lies in the expected subnet
@@ -197,7 +197,7 @@ describe Morph::DockerRunner do
 
       logs = []
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(result.status_code).to eq 1
@@ -216,7 +216,7 @@ describe Morph::DockerRunner do
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) do |s, c|
         logs << [Time.now, c]
       end
-      result = Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      result = Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         logs << [Time.now, c]
       end
       start_time = logs.find{|l| l[1] == "Started!\n"}[0]
@@ -232,7 +232,7 @@ describe Morph::DockerRunner do
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       # Simulate the log process stopping
       last_timestamp = nil
-      expect {Morph::DockerRunner.attach_to_run_and_finish2(c, []) do |timestamp, s, c|
+      expect {Morph::DockerRunner.attach_to_run_and_finish(c, []) do |timestamp, s, c|
         last_timestamp = timestamp
         logs << c
         if c == "2...\n"
@@ -241,7 +241,7 @@ describe Morph::DockerRunner do
       end}.to raise_error Sidekiq::Shutdown
       expect(logs).to eq ["Started!\n", "1...\n", "2...\n"]
       # Now restart the log process using the timestamp of the last log entry
-      Morph::DockerRunner.attach_to_run_and_finish2(c, [], last_timestamp) do |timestamp, s, c|
+      Morph::DockerRunner.attach_to_run_and_finish(c, [], last_timestamp) do |timestamp, s, c|
         logs << c
       end
       expect(logs).to eq ["Started!\n", "1...\n", "2...\n", "3...\n", "4...\n", "5...\n", "6...\n", "7...\n", "8...\n", "9...\n", "10...\n", "Finished!\n"]
@@ -252,7 +252,7 @@ describe Morph::DockerRunner do
 
       c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
       logs = []
-      Morph::DockerRunner.attach_to_run_and_finish2(c, [], nil, 5) do |timestamp, s, c|
+      Morph::DockerRunner.attach_to_run_and_finish(c, [], nil, 5) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(logs).to eq [


### PR DESCRIPTION
It turns out we've been reading the contents of the entire sqlite database into memory when copying the data out of a finished scraper in the sidekiq RunWorker process.

This is clearly not a good thing. This PR fixes this and instead reads everything into temporary files which get passed around. At no stage does the data read from the container get read into memory as a single blob.

This should hopefully also go some way (if not all the way) towards fixing #1066. However, we'll only really know when we deploy this to production and see what happens.