### PR TITLE
Dynamic concurrent scraper setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 
 services:
   - docker
+  - redis
 
 addons:
   apt:

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -27,6 +27,17 @@ ActiveAdmin.register_page "Dashboard" do
           button_to "Go into site-wide read-only mode", toggle_read_only_mode_admin_site_settings_path
         end
       end
+      para do
+        form action: update_maximum_concurrent_scrapers_admin_site_settings_path, method: :post do
+          div do
+            label 'Maximum concurrent scrapers'
+            input name: 'maximum_concurrent_scrapers', value: SiteSetting.maximum_concurrent_scrapers
+          end
+          div class: "buttons" do
+            input type: 'submit', value: 'Update'
+          end
+        end
+      end
       span class: "blank_slate" do
         span I18n.t("active_admin.dashboard_welcome.welcome")
         small I18n.t("active_admin.dashboard_welcome.call_to_action")

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -28,15 +28,7 @@ ActiveAdmin.register_page "Dashboard" do
         end
       end
       para do
-        form action: update_maximum_concurrent_scrapers_admin_site_settings_path, method: :post do
-          div do
-            label 'Maximum concurrent scrapers'
-            input name: 'maximum_concurrent_scrapers', value: SiteSetting.maximum_concurrent_scrapers
-          end
-          div class: "buttons" do
-            input type: 'submit', value: 'Update'
-          end
-        end
+        render "maximum_concurrent_scrapers_form"
       end
       span class: "blank_slate" do
         span I18n.t("active_admin.dashboard_welcome.welcome")

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -1,10 +1,5 @@
 module Admin
   class SiteSettingsController < ApplicationController
-    # Having to hand craft the form for post to update_maximum_concurrent_scrapers
-    # so doesn't include the authenticity_token. Not a big deal because it's only
-    # accessible by admins anyway
-    skip_before_filter :verify_authenticity_token, only: [:update_maximum_concurrent_scrapers]
-
     def toggle_read_only_mode
       authorize! :toggle_read_only_mode, SiteSetting
       SiteSetting.toggle_read_only_mode!

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -1,9 +1,21 @@
 module Admin
   class SiteSettingsController < ApplicationController
+    # Having to hand craft the form for post to update_maximum_concurrent_scrapers
+    # so doesn't include the authenticity_token. Not a big deal because it's only
+    # accessible by admins anyway
+    skip_before_filter :verify_authenticity_token, only: [:update_maximum_concurrent_scrapers]
+
     def toggle_read_only_mode
       authorize! :toggle_read_only_mode, SiteSetting
       SiteSetting.toggle_read_only_mode!
       flash[:notice] = "Read-only mode is now " + (SiteSetting.read_only_mode ? "on" : "off")
+      redirect_to admin_dashboard_url
+    end
+
+    def update_maximum_concurrent_scrapers
+      authorize! :update_sidekiq_maximum_concurrent_scrapers, SiteSetting
+      SiteSetting.maximum_concurrent_scrapers = params[:maximum_concurrent_scrapers]
+      flash[:notice] = "Updated maximum concurrent scrapers to #{SiteSetting.maximum_concurrent_scrapers}"
       redirect_to admin_dashboard_url
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -51,6 +51,7 @@ class Ability
     can [:index, :watching], User
     can :stats, User
     can :toggle_read_only_mode, SiteSetting if user.admin?
+    can :update_sidekiq_maximum_concurrent_scrapers, SiteSetting if user.admin?
 
     can :create, Run unless SiteSetting.read_only_mode
     # Define abilities for the passed in user here. For example:

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -14,14 +14,25 @@ class SiteSetting < ActiveRecord::Base
     self.read_only_mode = !read_only_mode
   end
 
-  private
+  def self.maximum_concurrent_scrapers
+    read_setting('maximum_concurrent_scrapers')
+  end
+
+  def self.maximum_concurrent_scrapers=(n)
+    write_setting('maximum_concurrent_scrapers', n)
+    update_sidekiq_maximum_concurrent_scrapers!
+  end
+
+  def self.update_sidekiq_maximum_concurrent_scrapers!
+    Sidekiq::Queue['scraper'].limit = maximum_concurrent_scrapers
+  end
 
   def self.record
     SiteSetting.first || SiteSetting.create(settings: defaults)
   end
 
   def self.read_setting(key)
-    record.settings[key]
+    record.settings[key] || defaults[key]
   end
 
   def self.write_setting(key, value)
@@ -29,6 +40,8 @@ class SiteSetting < ActiveRecord::Base
   end
 
   def self.defaults
-    { 'read_only_mode' => false }
+    { 'read_only_mode' => false, 'maximum_concurrent_scrapers' => 20 }
   end
+
+  private_class_method :record, :read_setting, :write_setting, :defaults
 end

--- a/app/views/admin/dashboard/_maximum_concurrent_scrapers_form.html.haml
+++ b/app/views/admin/dashboard/_maximum_concurrent_scrapers_form.html.haml
@@ -1,0 +1,6 @@
+= form_tag update_maximum_concurrent_scrapers_admin_site_settings_path, method: :post do
+  %div
+    = label_tag 'Maximum concurrent scrapers'
+    = number_field_tag 'maximum_concurrent_scrapers', SiteSetting.maximum_concurrent_scrapers
+  %div.buttons
+    = submit_tag 'Update'

--- a/app/views/admin/dashboard/_maximum_concurrent_scrapers_form.html.haml
+++ b/app/views/admin/dashboard/_maximum_concurrent_scrapers_form.html.haml
@@ -2,5 +2,11 @@
   %div
     = label_tag 'Maximum concurrent scrapers'
     = number_field_tag 'maximum_concurrent_scrapers', SiteSetting.maximum_concurrent_scrapers
+  %p
+    Each running scraper will use up to
+    = number_to_human_size Morph::DockerRunner.memory_limit
+    of memory. Ensure that the total can't use up the whole available memory
+    of the server.
+
   %div.buttons
     = submit_tag 'Update'

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
 # At Rails startup ensure that the sidekiq limit is in synch with the site
 # setting
-SiteSetting.update_sidekiq_maximum_concurrent_scrapers!
+if SiteSetting.table_exists?
+  SiteSetting.update_sidekiq_maximum_concurrent_scrapers!
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,3 @@
+# At Rails startup ensure that the sidekiq limit is in synch with the site
+# setting
+SiteSetting.update_sidekiq_maximum_concurrent_scrapers!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   namespace "admin" do
     resource :site_settings, only: [] do
       post "toggle_read_only_mode"
+      post "update_maximum_concurrent_scrapers"
     end
   end
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,5 +3,5 @@
 :queues:
   - default
   - scraper
-:limits:
-    scraper: 20
+# Limit of number of concurrent scrapers can now be changed dynamically from
+# the admin console. So, no need to set it here

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -25,4 +25,28 @@ describe SiteSetting do
       expect(SiteSetting.read_only_mode).to eq false
     end
   end
+
+  describe ".maximum_concurrent_scrapers" do
+    it "should be 20 by default" do
+      expect(SiteSetting.maximum_concurrent_scrapers).to eq 20
+    end
+
+    it "should persist a setting" do
+      SiteSetting.maximum_concurrent_scrapers = 10
+      expect(SiteSetting.maximum_concurrent_scrapers).to eq 10
+    end
+
+    it "should update the sidekiq value at the same time" do
+      expect(SiteSetting).to receive(:update_sidekiq_maximum_concurrent_scrapers!)
+      SiteSetting.maximum_concurrent_scrapers = 10
+    end
+  end
+
+  describe ".update_sidekiq_maximum_concurrent_scrapers!" do
+    it "should set the sidekiq value" do
+      SiteSetting.maximum_concurrent_scrapers = 10
+      SiteSetting.update_sidekiq_maximum_concurrent_scrapers!
+      expect(Sidekiq::Queue['scraper'].limit).to eq 10
+    end
+  end
 end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -48,7 +48,6 @@ describe SiteSetting do
 
       expect(Sidekiq::Queue['scraper']).to receive(:limit=).with(10)
       SiteSetting.update_sidekiq_maximum_concurrent_scrapers!
-      #expect(Sidekiq::Queue['scraper'].limit).to eq 10
     end
   end
 end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -45,8 +45,10 @@ describe SiteSetting do
   describe ".update_sidekiq_maximum_concurrent_scrapers!" do
     it "should set the sidekiq value" do
       SiteSetting.maximum_concurrent_scrapers = 10
+
+      expect(Sidekiq::Queue['scraper']).to receive(:limit=).with(10)
       SiteSetting.update_sidekiq_maximum_concurrent_scrapers!
-      expect(Sidekiq::Queue['scraper'].limit).to eq 10
+      #expect(Sidekiq::Queue['scraper'].limit).to eq 10
     end
   end
 end


### PR DESCRIPTION
First step in doing #1061. Allows an admin to change the number of concurrent scrapers on the fly from the admin panel.