### PR TITLE
Ensure that we're never running more scrapers than we should

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -15,7 +15,7 @@ class SiteSetting < ActiveRecord::Base
   end
 
   def self.maximum_concurrent_scrapers
-    read_setting('maximum_concurrent_scrapers')
+    read_setting('maximum_concurrent_scrapers').to_i
   end
 
   def self.maximum_concurrent_scrapers=(n)

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -70,6 +70,10 @@ module Morph
       end
     end
 
+    def self.find_all_containers_with_label(key)
+      Docker::Container.all(all:true, filters: {label: ["#{key}"]}.to_json)
+    end
+
     def self.copy_directory_contents(source, dest)
       FileUtils.cp_r File.join(source, '.'), dest
     end

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -74,6 +74,10 @@ module Morph
       Docker::Container.all(all:true, filters: {label: ["#{key}"]}.to_json)
     end
 
+    def self.find_all_containers_with_label_and_value(key, value)
+      Docker::Container.all(all:true, filters: {label: ["#{key}=#{value}"]}.to_json)
+    end
+
     def self.copy_directory_contents(source, dest)
       FileUtils.cp_r File.join(source, '.'), dest
     end

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -14,6 +14,19 @@ module Morph
       10_000
     end
 
+    def self.total_slots
+      SiteSetting.maximum_concurrent_scrapers
+    end
+
+    # This includes stopped containers too
+    def self.used_slots
+      Morph::DockerUtils.find_all_containers_with_label(run_label_key).count
+    end
+
+    def self.available_slots
+      total_slots - used_slots
+    end
+
     # The main section of the scraper running that is run in the background
     def synch_and_go!
       # If this run belongs to a scraper that has just been deleted

--- a/spec/lib/morph/docker_utils_spec.rb
+++ b/spec/lib/morph/docker_utils_spec.rb
@@ -95,4 +95,27 @@ describe Morph::DockerUtils do
       end
     end
   end
+
+  describe '.find_all_containers_with_label', docker: true do
+    before :each do
+      Morph::DockerUtils.find_all_containers_with_label('foobar').each do |c|
+        c.delete
+      end
+    end
+    after :each do
+      Morph::DockerUtils.find_all_containers_with_label('foobar').each do |c|
+        c.delete
+      end
+    end
+    it 'should find no containers with a particular label initially' do
+      expect(Morph::DockerUtils.find_all_containers_with_label('foobar').count).to eq 0
+    end
+
+    it 'should find two containers with the particular label when I create then' do
+      Docker::Container.create('Cmd' => ['ls'], 'Image' => 'openaustralia/buildstep', 'Labels' => {'foobar' => '1'})
+      Docker::Container.create('Cmd' => ['ls'], 'Image' => 'openaustralia/buildstep', 'Labels' => {'foobar' => '2'})
+      Docker::Container.create('Cmd' => ['ls'], 'Image' => 'openaustralia/buildstep', 'Labels' => {'bar' => '1'})
+      expect(Morph::DockerUtils.find_all_containers_with_label('foobar').count).to eq 2
+    end
+  end
 end

--- a/spec/workers/run_worker_spec.rb
+++ b/spec/workers/run_worker_spec.rb
@@ -13,4 +13,34 @@ describe RunWorker do
   it 'should do nothing if the run does not exist anymore' do
     RunWorker.new.perform(123456)
   end
+
+  context do
+    before :each do
+      Morph::DockerUtils.find_all_containers_with_label_and_value(Morph::Runner.run_label_key, '123456').each do |c|
+        c.delete
+      end
+    end
+    after :each do
+      Morph::DockerUtils.find_all_containers_with_label_and_value(Morph::Runner.run_label_key, '123456').each do |c|
+        c.delete
+      end
+    end
+
+    it 'should raise an exception if we already have the maximum number of running containers' do
+      run = Run.create!(id: 123456)
+      expect(Morph::Runner).to receive(:available_slots).and_return(0)
+      expect{RunWorker.new.perform(run.id)}.to raise_error RunWorker::NoRemainingSlotsError
+    end
+
+    it 'should not raise an exception if we are finishing off an already running container', docker: true do
+      run = Run.create!(id: 123456)
+      expect(Morph::Runner).to receive(:available_slots).and_return(0)
+      container = Docker::Container.create(
+        'Cmd' => ['ls'],
+        'Image' => 'openaustralia/buildstep',
+        'Labels' => {Morph::Runner.run_label_key => '123456'}
+      )
+      expect{RunWorker.new.perform(run.id)}.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #1061 by adding an extra guard in the RunWorker which checks if we have any available slots for starting a new run. If we're restarting an already existing run then it will always allow that through.
