### PR TITLE
Limit log lines in process

### DIFF
--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -70,7 +70,10 @@ module Morph
         }
       ) unless exists
 
-      command = Morph::TimeCommand.command(['/usr/local/bin/limit_output.rb', '/start scraper'], time_file)
+      command = Morph::TimeCommand.command(
+        ['/usr/local/bin/limit_output.rb', '0', '/start scraper'],
+        time_file
+      )
 
       # TODO: Also copy back time output file and the sqlite journal file
       # The sqlite journal file won't be present most of the time

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -32,7 +32,7 @@ module Morph
     end
 
     def self.compile_and_start_run(
-      repo_path, env_variables, container_labels
+      repo_path, env_variables, container_labels, max_lines = 0
     )
       i = buildstep_image do |c|
         yield(:internalout, c)
@@ -71,7 +71,7 @@ module Morph
       ) unless exists
 
       command = Morph::TimeCommand.command(
-        ['/usr/local/bin/limit_output.rb', '0', '/start scraper'],
+        ['/usr/local/bin/limit_output.rb', max_lines.to_s, '/start scraper'],
         time_file
       )
 
@@ -116,11 +116,9 @@ module Morph
     # If since is non-nil only return log lines since the time given. This
     # time is non-inclusive so we shouldn't return the log line with that
     # exact timestamp, just ones after it.
-    def self.attach_to_run_and_finish(container, files, since = nil,
-                                       max_lines = nil)
+    def self.attach_to_run_and_finish(container, files, since = nil)
       params = { stdout: true, stderr: true, follow: true, timestamps: true }
       params[:since] = since.to_f if since
-      line_count = 0
       container.streaming_logs(params) do |s, line|
         timestamp = Time.parse(line[0..29])
         # To convert this ruby time back to the same string format as it
@@ -137,18 +135,16 @@ module Morph
         # There is a chance that we catch a log line that shouldn't
         # be included. So...
         if since.nil? || timestamp > since
-          if max_lines.nil? || line_count < max_lines
-            yield timestamp, s, c
-          elsif line_count >= max_lines
-            yield nil, :internalerr,
+          if s == :stderr && c == "limit_output.rb: Too many lines of output!\n"
+            yield timestamp, :internalerr,
               "\n" \
               'Too many lines of output! ' \
               'Your scraper will continue uninterrupted. ' \
               'There will just be no further output displayed' \
               "\n"
-            break
+          else
+            yield timestamp, s, c
           end
-          line_count += 1
         end
       end
 

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -70,7 +70,7 @@ module Morph
         }
       ) unless exists
 
-      command = Morph::TimeCommand.command(['/start', 'scraper'], time_file)
+      command = Morph::TimeCommand.command(['/usr/local/bin/limit_output.rb', '/start scraper'], time_file)
 
       # TODO: Also copy back time output file and the sqlite journal file
       # The sqlite journal file won't be present most of the time
@@ -100,7 +100,10 @@ module Morph
       Dir.mktmpdir('morph') do |dest|
         copy_config_to_directory(repo_path, dest, false)
         yield(:internalout, "Injecting scraper and running...\n")
+        # TODO: Combine two operations below into one
         Morph::DockerUtils.insert_contents_of_directory(c, dest, '/app')
+        Morph::DockerUtils.insert_file(c, 'lib/morph/limit_output.rb',
+                                       '/usr/local/bin')
       end
 
       c.start

--- a/lib/morph/docker_utils.rb
+++ b/lib/morph/docker_utils.rb
@@ -182,6 +182,16 @@ module Morph
       File.delete(tar_file)
     end
 
+    # Inserts a single file into a container.
+    # Not using archive_in because that doesn't maintain file permissions
+    def self.insert_file(container, src, dest)
+      # This is very roundabout
+      Dir.mktmpdir('morph') do |tmp_dir|
+        FileUtils.cp(src, tmp_dir)
+        insert_contents_of_directory(container, tmp_dir, dest)
+      end
+    end
+
     # TODO: There's probably a more sensible way of doing this
     def self.image_built_on_other_image?(image, image_base)
       index = image.history.find_index { |l| l['Id'] == image_base.id }

--- a/lib/morph/limit_output.rb
+++ b/lib/morph/limit_output.rb
@@ -36,8 +36,8 @@ Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
       end
 
       # Just send this stuff straight through
-      STDOUT << io.readpartial(1024) if io.fileno == stdout.fileno
-      STDERR << io.readpartial(1024) if io.fileno == stderr.fileno
+      stream = io.fileno == stdout.fileno ? STDOUT : STDERR
+      stream << io.readpartial(1024)
     end
   end
 

--- a/lib/morph/limit_output.rb
+++ b/lib/morph/limit_output.rb
@@ -70,9 +70,11 @@ Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
   end
 
   # Output whatever is left in the buffers
-  STDOUT << stdout_buffer
-  STDERR << stderr_buffer
-
+  if line_count < max_lines || max_lines.zero?
+    STDOUT << stdout_buffer
+    STDERR << stderr_buffer
+  end
+  
   exit_status = wait_thr.value.exitstatus
 end
 

--- a/lib/morph/limit_output.rb
+++ b/lib/morph/limit_output.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+# This wrapper script runs a command and lets standard out and error flow
+# through. However, it does limit the number of lines of output. This is
+# used by morph as a wrapper around running scrapers to ensure that they
+# can't fill up the docker container log file (and hence the server disk).
+
+require 'optparse'
+require 'open3'
+
+command = nil
+exit_status = nil
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: ./limit_output.rb [command to run]'
+
+  command = ARGV[0]
+  if command.nil?
+    STDERR.puts 'Please give me a command to run'
+    puts opts
+    exit
+  end
+end.parse!
+
+Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
+  streams = [stdout, stderr]
+  until streams.empty?
+    IO.select(streams).flatten.compact.each do |io|
+      if io.eof?
+        streams.delete io
+        next
+      end
+
+      # Just send this stuff straight through
+      STDOUT << io.readpartial(1024) if io.fileno == stdout.fileno
+      STDERR << io.readpartial(1024) if io.fileno == stderr.fileno
+    end
+  end
+
+  exit_status = wait_thr.value.exitstatus
+end
+
+exit(exit_status)

--- a/lib/morph/limit_output.rb
+++ b/lib/morph/limit_output.rb
@@ -22,6 +22,10 @@ OptionParser.new do |opts|
   end
 end.parse!
 
+# Disable output buffering
+STDOUT.sync = true
+STDERR.sync = true
+
 Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
   streams = [stdout, stderr]
   until streams.empty?

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -250,9 +250,9 @@ describe Morph::DockerRunner do
     it 'should be able to limit the amount of log output' do
       copy_test_scraper('stream_output_ruby')
 
-      c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}) {}
+      c, _i3 = Morph::DockerRunner.compile_and_start_run(@dir, {}, {}, 5) {}
       logs = []
-      Morph::DockerRunner.attach_to_run_and_finish(c, [], nil, 5) do |timestamp, s, c|
+      Morph::DockerRunner.attach_to_run_and_finish(c, [], nil) do |timestamp, s, c|
         logs << [s, c]
       end
       expect(logs).to eq [


### PR DESCRIPTION
Much better solution to #919. This limits the log output at the process level by running the scraper within a wrapper script. This ensures that a scraper infinitely producing log lines will not fill up the log file within the docker container.