### PR TITLE
Routinely prune Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ config/database.yml
 coverage
 db/backups
 docker_images/morph-mitmdump/mitmproxy/mitmproxy-dhparam.pem
+playbook.retry

--- a/provisioning/roles/morph-app/files/docker-system-prune
+++ b/provisioning/roles/morph-app/files/docker-system-prune
@@ -1,0 +1,1 @@
+docker system prune --all --force

--- a/provisioning/roles/morph-app/files/docker-system-prune
+++ b/provisioning/roles/morph-app/files/docker-system-prune
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 docker system prune --all --force

--- a/provisioning/roles/morph-app/tasks/main.yml
+++ b/provisioning/roles/morph-app/tasks/main.yml
@@ -193,7 +193,7 @@
 
 - name: Add server name to /etc/hosts
   lineinfile: dest=/etc/hosts line="127.0.0.1 {{ server_name }}" owner=root group=root mode=0644
-  
+
 - name: Add faye server name to /etc/hosts
   lineinfile: dest=/etc/hosts line="127.0.0.1 faye.{{ server_name }}" owner=root group=root mode=0644
 

--- a/provisioning/roles/morph-app/tasks/main.yml
+++ b/provisioning/roles/morph-app/tasks/main.yml
@@ -219,3 +219,13 @@
 # https://github.com/github/markup#markups
 - name: Install dependency for restructured text support
   pip: name=docutils state=present
+
+# Vigorously clean unused docker data
+- name: Set up docker cleanup cron job
+  copy:
+    src: docker-system-prune
+    dest: /etc/cron.hourly/docker-system-prune
+    owner: root
+    group: root
+    mode: 0755
+  when: cron_jobs


### PR DESCRIPTION
- We are running out of disk space on the Morph box every 1-2 days. 
- There is a [bug](http://github.com/openaustralia/morph/issues/1104) that is causing Docker to create a heap of AUFS diffs that don't get cleaned up. 
- Until we have the time and space to resolve that, we need some quick, automated bits to keep the pressure off disk space exhaustion. 
- This PR gets the Morph box running `docker system prune --all --force` every hour. 
- This should take the pressure down. 

[![John Farnham – Pressure Down](https://img.youtube.com/vi/Emutat3_IP0/0.jpg)](https://www.youtube.com/watch?v=Emutat3_IP0)
