### PR TITLE
Put in a logrotate for morph-app run out of Upstart

### DIFF
--- a/provisioning/roles/morph-app/meta/main.yml
+++ b/provisioning/roles/morph-app/meta/main.yml
@@ -21,3 +21,11 @@ dependencies:
           - compress
           - missingok
           - copytruncate
+      - name: morph
+        path: "/var/log/morph/*.log"
+        options:
+          - daily
+          - rotate 7
+          - compress
+          - missingok
+          - copytruncate

--- a/provisioning/roles/nickhammond.logrotate/tasks/main.yml
+++ b/provisioning/roles/nickhammond.logrotate/tasks/main.yml
@@ -6,5 +6,5 @@
   template:
     src: logrotate.d.j2
     dest: /etc/logrotate.d/{{ item.name }}
-  with_items: logrotate_scripts
+  with_items: "{{ logrotate_scripts }}"
   when: logrotate_scripts is defined


### PR DESCRIPTION
Discovered that upstart launching Morph had 1.3G of log files that weren't being rotated:

```
root@li421-88:/var/log# du -csh /var/log/morph/*.log
1020K   /var/log/morph/backtrace.log
4.6M    /var/log/morph/faye-1.log
110M    /var/log/morph/mitmproxy-1.log
616M    /var/log/morph/worker-1.log
592M    /var/log/morph/worker-2.log
1.3G    total
```

Some of the log entries go back to 2016-06. 

This PR puts a logrotate script in for morph-app running out of upstart.