### PR TITLE
[WIP] Make backups easier to understand. 

### DIFF
--- a/provisioning/roles/backups/files/database-backup.sh
+++ b/provisioning/roles/backups/files/database-backup.sh
@@ -21,11 +21,17 @@ setup_backup() {
   umask 077
 }
 
+# Free up all available disk space before a backup happens.
+free_all_available_disk_space() {
+  docker system prune --all --force
+}
+
 set -e
 BACKUP_DIR="/backups/mysql"
 MAX_BACKUPS=1
 
 setup_backup
+free_all_available_disk_space
 perform_backup
 count_backups
 

--- a/provisioning/roles/backups/files/database-backup.sh
+++ b/provisioning/roles/backups/files/database-backup.sh
@@ -1,19 +1,35 @@
 #!/bin/sh
 
 # Backup the database to /backups/mysql and keep the last five days around
-# This script should be run from a cron job once per days
+# This script should be run from a cron job once a day.
 
+count_backups() {
+  backup_count="$(ls -1 $BACKUP_DIR | wc -l)"
+}
+
+find_oldest_backup() {
+  oldest_backup="$BACKUP_DIR/$(ls -1rt $BACKUP_DIR | head -n 1)"
+}
+
+perform_backup() {
+  innobackupex --compress $BACKUP_DIR --user=root
+}
+
+setup_backup() {
+  mkdir -p $BACKUP_DIR
+  # Created files should just readable (and writeable) by root
+  umask 077
+}
+
+set -e
 BACKUP_DIR="/backups/mysql"
-mkdir -p $BACKUP_DIR
-# Created files should just readable (and writeable) by root
-umask 077 
 
-/usr/bin/innobackupex --compress $BACKUP_DIR --user=root
+setup_backup
+perform_backup
+count_backups
 
-no_backups=`ls -1 $BACKUP_DIR | wc -l`
-while [ $no_backups -gt 5 ]
-do
-  oldest=`ls -1rt $BACKUP_DIR | head -n 1`
-  rm -rf $BACKUP_DIR/$oldest
-  no_backups=`ls -1 $BACKUP_DIR | wc -l`
+while [ $backup_count -gt 1 ]; do
+  find_oldest_backup
+  rm -rf $oldest_backup
+  count_backups
 done

--- a/provisioning/roles/backups/files/database-backup.sh
+++ b/provisioning/roles/backups/files/database-backup.sh
@@ -23,12 +23,13 @@ setup_backup() {
 
 set -e
 BACKUP_DIR="/backups/mysql"
+MAX_BACKUPS=1
 
 setup_backup
 perform_backup
 count_backups
 
-while [ $backup_count -gt 1 ]; do
+while [ $backup_count -gt $MAX_BACKUPS ]; do
   find_oldest_backup
   rm -rf $oldest_backup
   count_backups


### PR DESCRIPTION
**This PR is a Work in Progress. Please don't merge until I say I think it's in an OK state.**

I've refactored the backup script into functions. 

The intention is to make the logic easier to follow, so the operator doesn't need to know all the details of how the backups are performed. 

Currently the only logic change is the number of backups to retain (was previously 5, now set to 1, due to disk space problems per #1104)