### PR TITLE
Add a script to clean up tmp directories in Docker AUFS layers

### DIFF
--- a/provisioning/roles/morph-app/files/docker-aufs-clean-tmps
+++ b/provisioning/roles/morph-app/files/docker-aufs-clean-tmps
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Per this Docker AUFS bug, disk space is slowly being eaten up by containers
+# that aren't being cleaned up by a `docker system prune --all --force`:
+#
+# https://github.com/docker/docker/issues/22207
+#
+# Ideally we could just nuke all AUFS data in `/var/lib/docker/aufs/diff`,
+# but the Morph box is running two types of workloads: scrapers, and long
+# running processes. If we blindly nuke the AUFS data, we may accidentally nuke
+# persistent data from a long running process (like a Discourse upload, or a
+# Postgres database :-| ).
+#
+# We can take advantage of the UNIX convention that data stored in /tmp is
+# ephemeral, by only nuking tmp directories in any image stored in
+# `/var/lib/docker/aufs/diff`. Any containers working with data in /tmp
+# should generally recover seamlessly, and this gives us a significant space
+# saving.
+#
+# This script finds any tmp directories under `/var/lib/docker/aufs/diffs` with
+# more than 1MB of usage, and deletes them.
+#
+# It also prints out the number of files deleted, and the amount of space
+# recovered by running the script.
+
+set -e
+
+sizes_path=$(mktemp)
+find /var/lib/docker/aufs/diff -maxdepth 2 -type d -name 'tmp' | xargs du -hs > $sizes_path
+
+ids="$(cat $sizes_path | sort -h | egrep ^.*[0-9][0-9]M | cut -d '/' -f 7)"
+sizes="$(cat $sizes_path | sort -h | egrep ^.*[0-9][0-9]M | cut -d 'M' -f 1)"
+
+for t in $ids; do
+  rm -rf /var/lib/docker/aufs/diff/$t/tmp
+done
+
+echo "Targets to delete: $(echo $ids |tr ' ' '\n' | wc -l)"
+echo "Full file list: $sizes_path"
+echo "Space recovered: $(expr $(echo $sizes| sed 's/ / + /g') + 0)M"

--- a/provisioning/roles/morph-app/tasks/main.yml
+++ b/provisioning/roles/morph-app/tasks/main.yml
@@ -229,3 +229,13 @@
     group: root
     mode: 0755
   when: cron_jobs
+
+# Attempt to safely clean up around AUFS bug https://github.com/docker/docker/issues/22207
+- name: Set up AUFS cleanup cron job
+  copy:
+    src: docker-aufs-clean-tmps
+    dest: /etc/cron.daily/docker-aufs-clean-tmps
+    owner: root
+    group: root
+    mode: 0755
+  when: cron_jobs


### PR DESCRIPTION
Per the [Docker AUFS bug](https://github.com/docker/docker/issues/22207) affecting us in #1104, disk space is slowly being eaten up by containers that aren't being cleaned up by a `docker system prune --all --force`.

Ideally we could just nuke all AUFS data in `/var/lib/docker/aufs/diff`, but the Morph box is running two types of workloads: scrapers, and long running processes. If we blindly nuke the AUFS data, we may accidentally nuke persistent data from a long running process (like a Discourse upload, or a
Postgres database 😬 ).

We can take advantage of the UNIX convention that data stored in `/tmp` is ephemeral, by only nuking `/tmp` directories in any image stored in `/var/lib/docker/aufs/diff`. Any containers working with data in `/tmp` should generally recover seamlessly, and this gives us a significant space saving. 

By running this script once, I managed to recover ~140GB of disk space.

![image](https://cloud.githubusercontent.com/assets/12306/22505447/a97a497e-e8cf-11e6-8d5d-0638e7bdd60c.png)

This script finds any tmp directories under filesystem layers in `/var/lib/docker/aufs/diffs` with more than 1MB of usage, and deletes them.

It also prints out the number of files deleted, and the amount of space recovered by running the script.

This PR installs the script as a cron job that runs once a day. 