### PR TITLE
Fix hidden headers behind navbar caused by anchor links in documentation

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -49,3 +49,8 @@ body {
 .jumbotron p {
   font-weight: normal;
 }
+
+.section {
+  padding-top: 50px;
+  margin-top: -30px;
+}


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/morph/issues/875
When anchor links are used, the header gets hidden behind the navigation bar.
It is caused by default in Bootstrap, and has been corrected in this commit by overriding the default values.
This commit does not change the spacing values of this page or any other pages; only the anchor links are made visible by shifting below.

For eg, if we open the page https://morph.io/documentation#languages

Initially, it looked like

![uploadorig](https://cloud.githubusercontent.com/assets/16884926/24402196/1e6bfea0-13d5-11e7-8585-dddb03a5a103.jpg)
-----------------------------------------------------------------------------------------

After the commit, it would look like,

![uploadini](https://cloud.githubusercontent.com/assets/16884926/24402139/e1d3e0c0-13d4-11e7-9a5a-782eaacfdb57.jpg)
