### PR TITLE
Disable Clear database button if scraper is empty

### DIFF
--- a/app/views/scrapers/_danger.html.haml
+++ b/app/views/scrapers/_danger.html.haml
@@ -16,9 +16,14 @@
                   of scraped data will be gone!
                 - else
                   All your data will be gone!
-              = button_to clear_scraper_path(@scraper), {class: "btn btn-warning", data: {confirm: "All the data you’ve scraped will be deleted. Are you sure you want to clear your scraper’s database?"}} do
-                Clear database
-                %i.glyphicon.glyphicon-th-list
+              - if @scraper.has_data?
+                = button_to clear_scraper_path(@scraper), {class: "btn btn-warning", data: {confirm: "All the data you’ve scraped will be deleted. Are you sure you want to clear your scraper’s database?"}} do
+                  Clear database
+                  %i.glyphicon.glyphicon-th-list
+              - else 
+                = button_to "#", class: "btn btn-disabled", disabled: "disabled" do
+                  Clear database
+                  %i.glyphicon.glyphicon-th-list
           %li.list-group-item
             %h4 Delete your scraper
             .danger-settings-action-body


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/morph/issues/983
If the scraper is empty, the button to clear the database on the settings page must be disabled for ease to the user. 
So, in this commit, the design and action of the button has been changed to make it disabled if the scraper is empty.