### PR TITLE
 Size of header search made consistent for medium width screens

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -68,3 +68,18 @@
     }
   }
 }
+
+#searchf .input-group {
+  width:100%;
+}
+
+@media (min-width: $screen-sm-min) {
+  #searchf .input-group .input-group-addon, #searchf .input-group .input-group-btn, #searchf .input-group .form-control {
+    width:0;
+  }
+}
+@media (min-width: $screen-sm-min) {
+  #searchf .input-group > .form-control {
+    width:100%;
+  }
+}

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -69,17 +69,17 @@
   }
 }
 
-#searchf .input-group {
+#nav-search-form .input-group {
   width:100%;
 }
 
 @media (min-width: $screen-sm-min) {
-  #searchf .input-group .input-group-addon, #searchf .input-group .input-group-btn, #searchf .input-group .form-control {
+  #nav-search-form .input-group .input-group-addon, #nav-search-form .input-group .input-group-btn, #nav-search-form .input-group .form-control {
     width:0;
   }
 }
 @media (min-width: $screen-sm-min) {
-  #searchf .input-group > .form-control {
+  #nav-search-form .input-group > .form-control {
     width:100%;
   }
 }

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -37,7 +37,7 @@
           - else
             = link_to "Sign in with GitHub", user_github_omniauth_authorize_path
 
-      = form_tag search_path, method: "get", role: "search", class: "navbar-form navbar-right" do
+      = form_tag search_path, method: "get", role: "search", class: "navbar-form navbar-right", id: "searchf" do
         .input-group
           = label_tag :q, "Search", class: 'sr-only'
           = search_field_tag :q, @q, maxlength: "256", name: "q", type: "search", placeholder: "Search", class: "form-control"

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -37,7 +37,7 @@
           - else
             = link_to "Sign in with GitHub", user_github_omniauth_authorize_path
 
-      = form_tag search_path, method: "get", role: "search", class: "navbar-form navbar-right", id: "searchf" do
+      = form_tag search_path, method: "get", role: "search", class: "navbar-form navbar-right", id: "nav-search-form" do
         .input-group
           = label_tag :q, "Search", class: 'sr-only'
           = search_field_tag :q, @q, maxlength: "256", name: "q", type: "search", placeholder: "Search", class: "form-control"


### PR DESCRIPTION
This pull request aims to fix the issue #585
The width of the header search becomes small at the wider end of the screen, i.e., for widths between 768px to 1200px. 
For small (<768) and large (>1200) width screens, the search bar size was already consistent.
Now, search bar width has been made consistent for medium width screens as well. 

For medium width screen : 
![searchbarfixed](https://cloud.githubusercontent.com/assets/16884926/24528362/c048ed88-15c3-11e7-83eb-c6c2832c33d0.png)
