### PR TITLE
Make user menu show up on small screens. Fix to #918.

### DIFF
--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -22,7 +22,7 @@
       %ul.nav.navbar-nav.navbar-right
         %li
           - if user_signed_in?
-            %li(class="dropdown hidden-sm")
+            %li(class="dropdown")
               %a(href="#" class="dropdown-toggle" data-toggle="dropdown")
                 = owner_image(current_user, 20, false)
                 = current_user.nickname


### PR DESCRIPTION
"hidden-sm" class on user menu seems to be preventing it from being displayed on small screens. This pull request removes "hidden-sm" class from it and thus fixes #918.
Here is video illustrating fix https://goo.gl/DmWWUx
Example of user menu with fix applied:
![user](https://cloud.githubusercontent.com/assets/20787120/24730973/a0a67b2a-1a6f-11e7-8423-682ca1d3bacd.png)
