### PR TITLE
Fix error when trying to delete scrapers

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -16,6 +16,8 @@ class Run < ActiveRecord::Base
 
   before_create { |run| run.build_metric }
 
+  before_destroy { |run| Metric.where(run_id: run.id).destroy_all }
+
   # TODO: Run requires an owner - add a validation for that
 
   def database

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -14,6 +14,8 @@ class Run < ActiveRecord::Base
            to: :scraper, allow_nil: true
   delegate :utime, :stime, :cpu_time, to: :metric, allow_nil: true
 
+  before_create { |run| run.build_metric }
+
   # TODO: Run requires an owner - add a validation for that
 
   def database

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -144,8 +144,7 @@ module Morph
       end
 
       # Now collect and save the metrics
-      metric = Metric.create(result.time_params) if result.time_params
-      metric.update_attributes(run_id: run.id) if metric
+      run.metric.update_attributes(result.time_params) if result.time_params
 
       # Update information about what changed in the database
       diffstat = Morph::SqliteDiff.diffstat_safe(

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -67,4 +67,20 @@ describe Run do
       expect(run.metric).to be_present
     end
   end
+
+  describe '#destroy' do
+    context 'with more than one metric for a single run' do
+      let(:run) { Run.create! }
+
+      before do
+        2.times { Metric.create!(run: run) }
+      end
+
+      it 'does not raise an error' do
+        expect {
+          run.destroy
+        }.to change(Run, :count).by(-1)
+      end
+    end
+  end
 end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -60,4 +60,11 @@ describe Run do
       run.finished!
     end
   end
+
+  describe '#metric' do
+    it 'is present after creation' do
+      run = Run.create!
+      expect(run.metric).to be_present
+    end
+  end
 end


### PR DESCRIPTION
## What does this do?

This fixes the problem with deleting scrapers due to a foreign key error that was originally reported in https://github.com/openaustralia/morph/issues/1084.

## Why was this needed?

When a run has multiple metrics associated with it, trying to destroy it causes an error. This is because Run is supposed to `have_one` Metric, but this isn't being enforced at the database level, so there are certain runs that have more than one metric associated with them.

## Implementation notes

For now, I've fixed this at the application level. I attempted to write a migration to add a database constraint, but it proved tricky because there's already an index on the `metrics.run_id` column and my mysql/rails migration skills fell short of a satisfying solution. 

I'm happy to be persuaded that we should still add a database constraint/script to tidy up old data, but perhaps we can do that as a separate issue with a separate pull request? Either way, I think there's value in getting this live so that we can fix the user-facing error, at least.

## Related issues

Fixes https://github.com/openaustralia/morph/issues/1084