### PR TITLE
Stop api requests that were erroring from hanging

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -98,10 +98,15 @@ class ApiController < ApplicationController
       mime_type = params[:callback] ? 'application/javascript': 'application/json'
       response.headers['Content-Type'] = "#{mime_type}; charset=utf-8"
       response.stream.write("/**/#{params[:callback]}(")  if params[:callback]
-      response.stream.write("[\n")
       i = 0
       @scraper.database.sql_query_streaming(params[:query]) do |row|
-        response.stream.write("\n,") unless i == 0
+        # In case there is an error with the query wait for that to work before
+        # generating the first output
+        if i == 0
+          response.stream.write("[\n")
+        else
+          response.stream.write("\n,")
+        end
         s = row.to_json
         size += s.size
         response.stream.write(s)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -39,12 +39,12 @@ class ApiController < ApplicationController
     # of the api don't have to change anything
     api_key = request.headers['HTTP_X_API_KEY'] || params[:key]
     if api_key.nil?
-      render_error 'API key is missing'
+      render_error 'API key is missing', 401
       return
     else
       owner = Owner.find_by_api_key(api_key)
       if owner.nil?
-        render_error 'API key is not valid'
+        render_error 'API key is not valid', 401
         return
       end
     end
@@ -58,7 +58,7 @@ class ApiController < ApplicationController
       end
 
     rescue SQLite3::Exception => e
-      render_error e.to_s
+      render_error e.to_s, 400
     end
   ensure
     response.stream.close
@@ -231,8 +231,8 @@ class ApiController < ApplicationController
     )
   end
 
-  def render_error(message)
-    response.status = 401
+  def render_error(message, status)
+    response.status = status
 
     respond_to do |format|
       format.sqlite {

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -198,8 +198,12 @@ class ApiController < ApplicationController
     bench = Benchmark.measure do
       # Tell nginx and passenger not to buffer this
       response.headers['X-Accel-Buffering'] = 'no'
-      atom_header
+      displayed_header = false
       @scraper.database.sql_query_streaming(params[:query]) do |row|
+        unless displayed_header
+          atom_header
+          displayed_header = true
+        end
         s = ""
         s << "  <entry>\n"
         s << "    <title>#{row['title']}</title>\n"
@@ -210,6 +214,9 @@ class ApiController < ApplicationController
         s << "  </entry>\n"
         size += s.size
         response.stream.write(s)
+      end
+      unless displayed_header
+        atom_header
       end
       atom_footer
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -138,6 +138,13 @@ class ApiController < ApplicationController
     )
   end
 
+  # Returns the size of the header
+  def csv_header(row)
+    s = row.keys.to_csv
+    response.stream.write(s)
+    s.size
+  end
+
   def data_csv(owner)
     size = 0
     bench = Benchmark.measure do
@@ -148,9 +155,7 @@ class ApiController < ApplicationController
       @scraper.database.sql_query_streaming(params[:query]) do |row|
         # only show the header once at the beginning
         unless displayed_header
-          s = row.keys.to_csv
-          size += s.size
-          response.stream.write(s)
+          size += csv_header(row)          
           displayed_header = true
         end
         s = row.values.to_csv

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -197,7 +197,10 @@ class ApiController < ApplicationController
   def render_error(message)
     respond_to do |format|
       format.sqlite { render text: message, status: 401, content_type: :text }
-      format.json { render json: { error: message }, status: 401 }
+      format.json {
+        response.status = 401
+        response.stream.write({ error: message }.to_json)
+      }
       format.csv { render text: message, status: 401, content_type: :text }
       format.atom { render text: message, status: 401, content_type: :text }
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -205,14 +205,24 @@ class ApiController < ApplicationController
   end
 
   def render_error(message)
+    response.status = 401
+
     respond_to do |format|
-      format.sqlite { render text: message, status: 401, content_type: :text }
+      format.sqlite {
+        response.content_type = 'text'
+        response.stream.write(message)
+      }
       format.json {
-        response.status = 401
         response.stream.write({ error: message }.to_json)
       }
-      format.csv { render text: message, status: 401, content_type: :text }
-      format.atom { render text: message, status: 401, content_type: :text }
+      format.csv {
+        response.content_type = 'text'
+        response.stream.write(message)
+      }
+      format.atom {
+        response.content_type = 'text'
+        response.stream.write(message)
+      }
     end
   end
 


### PR DESCRIPTION
When the api was updated to to do streaming output it caused a new problem where if there was an error (it could be something as simple as invalid sql) the api request would hang rather than responding with an error message.

This fixes that problem and hopefully might address #1177 as well. We'll see!