### PR TITLE
Enable multiple platforms

### DIFF
--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -266,6 +266,16 @@ class Scraper < ActiveRecord::Base
     Morph::Database.new(data_path)
   end
 
+  def platform
+    platform_file = "#{repo_path}/platform"
+    if File.exist?(platform_file)
+      platform = File.read(platform_file)
+    else
+      platform = "latest"
+    end
+    platform.chomp
+  end
+
   # It seems silly implementing this
   def self.directory_size(directory)
     r = 0

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -34,8 +34,14 @@ module Morph
     end
 
     def self.compile_and_start_run(
-      repo_path, env_variables, container_labels, max_lines = 0, platform = "latest"
-    ) 
+      repo_path, env_variables, container_labels, max_lines = 0, scraper = nil
+        )
+      if scraper.nil? || scraper.platform.nil?
+        platform = "latest"
+      else
+        platform = scraper.platform
+      end
+
       i = buildstep_image(platform) do |c|
         yield(:internalout, c)
       end

--- a/lib/morph/docker_runner.rb
+++ b/lib/morph/docker_runner.rb
@@ -27,14 +27,16 @@ module Morph
       512 * 1024 * 1024
     end
 
-    def self.buildstep_image
-      Morph::DockerUtils.get_or_pull_image(BUILDSTEP_IMAGE)
+    def self.buildstep_image(platform = "latest")
+      image = "#{BUILDSTEP_IMAGE}:#{platform}"
+      puts "Using image #{image}"
+      Morph::DockerUtils.get_or_pull_image(image)
     end
 
     def self.compile_and_start_run(
-      repo_path, env_variables, container_labels, max_lines = 0
-    )
-      i = buildstep_image do |c|
+      repo_path, env_variables, container_labels, max_lines = 0, platform = "latest"
+    ) 
+      i = buildstep_image(platform) do |c|
         yield(:internalout, c)
       end
       yield(:internalout, "Injecting configuration and compiling...\n")

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -106,7 +106,7 @@ module Morph
         Morph::Runner.add_sqlite_db_to_directory(run.data_path, defaults)
 
         Morph::DockerRunner.compile_and_start_run(
-          defaults, run.env_variables, docker_container_labels, max_lines, run.scraper.platform
+          defaults, run.env_variables, docker_container_labels, max_lines, run.scraper
         ) do |s, c|
           yield(s, c)
         end

--- a/lib/morph/runner.rb
+++ b/lib/morph/runner.rb
@@ -106,7 +106,7 @@ module Morph
         Morph::Runner.add_sqlite_db_to_directory(run.data_path, defaults)
 
         Morph::DockerRunner.compile_and_start_run(
-          defaults, run.env_variables, docker_container_labels, max_lines
+          defaults, run.env_variables, docker_container_labels, max_lines, run.scraper.platform
         ) do |s, c|
           yield(s, c)
         end


### PR DESCRIPTION
The goal of this change is to allow a scraper to pick from a set of
supported platforms by use of the `platform` file. If no platform is
selected, `openaustralia/buildstep:latest` is implicity used, matching
current behaviour. I've already created
https://github.com/openaustralia/buildstep/tree/early_release as an
alternate platform. Although this is not yet on Dockerhub, manual
testing has confirmed that `openaustralia/buildstep:early_release`
does get used if the image already exists locally.

Other potential platform tags might be `heroku_16` and `heroku_18`; or
`herokuish_v0.4.8`; or `deprecated` for people who still need
`cedar:14` after we stop supporting that.