### PR TITLE
Simpler local deploy - push directly from local repo

### DIFF
--- a/config/deploy/local.rb
+++ b/config/deploy/local.rb
@@ -1,6 +1,20 @@
 set :stage, :local
 set :rails_env, :production
 
+before :deploy, :deploy_from_local_repo
+
+task :deploy_from_local_repo do
+  set :repo_url,  "file:///tmp/.git"
+  set :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
+  run_locally do
+    execute "tar -zcvf /tmp/repo.tgz .git"
+  end
+  on roles(:all) do
+    upload! '/tmp/repo.tgz', '/tmp/repo.tgz'
+    execute 'tar -zxvf /tmp/repo.tgz -C /tmp'
+  end
+end
+
 role :app, %w{deploy@localhost}
 role :web, %w{deploy@localhost}
 role :db,  %w{deploy@localhost}


### PR DESCRIPTION
I've found that this enables me to iterate much faster, as I can push
something and try it out without needing to round-trip through Github.