### PR TITLE
Fix mismatched quotes in github_users list

### DIFF
--- a/provisioning/roles/ruby/meta/main.yml
+++ b/provisioning/roles/ruby/meta/main.yml
@@ -4,7 +4,7 @@ dependencies:
     github_users: 
     - 'br3nda'
     - 'henare'
-    - "ianheggie-oaf'
+    - 'ianheggie-oaf'
     - 'jamezpolley'
     - 'mlandauer'
     - 'simonzippy'


### PR DESCRIPTION
Fix an opsy in last minute change with only one not both double quotes changed to single quote.