### PR TITLE
Fix backup database script

### DIFF
--- a/provisioning/roles/backups/files/database-backup.sh
+++ b/provisioning/roles/backups/files/database-backup.sh
@@ -1,19 +1,47 @@
-#!/bin/sh
+#!/bin/bash
 
-# Backup the database to /backups/mysql and keep the last five days around
-# This script should be run from a cron job once per days
+# Backup all databases to /backups/mysql with timestamps
+# Run as root from cron daily
 
-BACKUP_DIR="/backups/mysql"
-mkdir -p $BACKUP_DIR
-# Created files should just readable (and writeable) by root
-umask 077 
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
 
-/usr/bin/innobackupex --compress $BACKUP_DIR --user=root
+BACKUP_DIR="${BACKUP_DIR:-/backups/mysql}"
+mkdir -p "$BACKUP_DIR"
+umask 077
+# bash only option: Check mysqldump as well as zstd in pipe for failure
+set -o pipefail
 
-no_backups=`ls -1 $BACKUP_DIR | wc -l`
-while [ $no_backups -gt 5 ]
-do
-  oldest=`ls -1rt $BACKUP_DIR | head -n 1`
-  rm -rf $BACKUP_DIR/$oldest
-  no_backups=`ls -1 $BACKUP_DIR | wc -l`
+OPTIONS="--add-drop-table --single-transaction --no-tablespaces"
+
+# Skip system databases
+SKIP_DATABASES="^(Database|mysql|sys|information_schema|performance_schema)$"
+
+# Get list of databases
+DATABASES=$(mysql --user=root -e "SHOW DATABASES;" | grep -v -E "$SKIP_DATABASES")
+
+exit_status=0
+# Loop through each database
+for DB_NAME in $DATABASES; do
+    BACKUP_NAME="$DB_NAME.$TIMESTAMP.sql.zst"
+    echo "Dumping database: $DB_NAME to $BACKUP_NAME"
+
+    # compress inline so we need only about 5% not 50% of the disk available
+    # shellcheck disable=SC2086
+    if mysqldump --user=root $OPTIONS "$DB_NAME" | zstd -T0 -9 > "$BACKUP_DIR/$BACKUP_NAME.tmp"; then
+        mv -f "$BACKUP_DIR/$BACKUP_NAME.tmp" "$BACKUP_DIR/$BACKUP_NAME"
+        echo "Successfully dumped $DB_NAME"
+    else
+        echo "Error dumping $DB_NAME" >&2
+        rm -f "$BACKUP_DIR/$BACKUP_NAME.tmp"
+        exit_status=1  # Fail at end so other databases may get backed up
+    fi
 done
+
+# Keep only the 5 most recent backups for each database
+for DB_NAME in $DATABASES; do
+    # shellcheck disable=SC2012
+    ls -1t "$BACKUP_DIR/$DB_NAME."*.sql.zst 2>/dev/null | tail -n +6 | xargs -r rm -f
+done
+
+echo "MySQL database backup completed."
+echo "$exit_status"

--- a/provisioning/roles/morph-app/tasks/main.yml
+++ b/provisioning/roles/morph-app/tasks/main.yml
@@ -207,11 +207,11 @@
   template: src=duply_sqlite_conf dest=/root/.duply/sqlite/conf owner=root group=root mode=0400
 
 - name: Do backups daily of mysql to S3 at 4:40AM
-  cron: name="duply mysql" hour=4 minute=40 user=root job="duply mysql backup"
+  cron: name="duply mysql" hour=4 minute=40 user=root job="ulimit -n 65536 && duply mysql backup"
   when: backups
 
 - name: Do backups daily of sqlite to S3 at 4:40AM
-  cron: name="duply sqlite" hour=4 minute=40 user=root job="duply sqlite backup"
+  cron: name="duply sqlite" hour=4 minute=40 user=root job="ulimit -n 65536 && duply sqlite backup"
   when: backups
 
 - name: Sync configuration

--- a/provisioning/roles/morph-app/templates/duply_mysql_conf
+++ b/provisioning/roles/morph-app/templates/duply_mysql_conf
@@ -4,4 +4,12 @@ TARGET='s3://s3.amazonaws.com/oaf-backups/morph/mysql'
 export AWS_ACCESS_KEY_ID='{{ backup_target_user }}'
 export AWS_SECRET_ACCESS_KEY='{{ backup_target_pass }}'
 SOURCE='/backups'
-MAX_AGE=6M
+# MAX_AGE wasn't effective, but its still required
+MAX_AGE=7M
+# Force new full backup every month
+MAX_FULLBKP_AGE=1M
+# Keep only 6 full backup chains
+MAX_FULL_BACKUPS=6
+
+# Use 500 GB chunks (typically 15 chunks taking around 30 sec each)
+DUPL_PARAMS="$DUPL_PARAMS --volsize 500"

--- a/provisioning/roles/morph-app/templates/duply_sqlite_conf
+++ b/provisioning/roles/morph-app/templates/duply_sqlite_conf
@@ -4,4 +4,12 @@ TARGET='s3://s3.amazonaws.com/oaf-backups/morph/sqlite'
 export AWS_ACCESS_KEY_ID='{{ backup_target_user }}'
 export AWS_SECRET_ACCESS_KEY='{{ backup_target_pass }}'
 SOURCE='/var/www/shared/db/scrapers/data'
-MAX_AGE=6M
+# MAX_AGE wasn't effective, but its still required
+MAX_AGE=7M
+# Force new full backup every month
+MAX_FULLBKP_AGE=1M
+# Keep only 6 full backup chains
+MAX_FULL_BACKUPS=6
+
+# Use 500 GB chunks (typically 15 chunks taking around 30 sec each)
+DUPL_PARAMS="$DUPL_PARAMS --volsize 500"


### PR DESCRIPTION
This is the fix I applied manually to production to get backup database script working.

I also cleared out the backup files that where years old because the config has MAX_AGE=6M and it was being ignored.