### PR TITLE
Hotfix to trim log lines table (already deployed to production) [Merge 1st to main]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,9 @@ group :development do
 
   gem "capistrano-rails"
   gem "capistrano-rvm"
+  gem "ed25519", "~> 1.3"
+  gem "bcrypt_pbkdf", "~> 1.1"
+
   gem "growl"
   gem "guard"
   gem "guard-livereload", require: false
@@ -207,3 +210,4 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       railties (> 3.1)
     base64 (0.3.0)
     bcrypt (3.1.18)
+    bcrypt_pbkdf (1.1.1)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -170,6 +171,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    ed25519 (1.3.0)
     elasticsearch (7.17.11)
       elasticsearch-api (= 7.17.11)
       elasticsearch-transport (= 7.17.11)
@@ -690,6 +692,7 @@ DEPENDENCIES
   activeadmin
   archive-tar-minitar
   backstretch-rails
+  bcrypt_pbkdf (~> 1.1)
   better_errors
   binding_of_caller
   bootsnap (~> 1.4)
@@ -707,6 +710,7 @@ DEPENDENCIES
   devise
   docker-api
   dotenv-rails
+  ed25519 (~> 1.3)
   elasticsearch (~> 7.17)
   factory_bot_rails
   faraday (~> 2)

--- a/app/models/connection_log.rb
+++ b/app/models/connection_log.rb
@@ -5,6 +5,8 @@
 class ConnectionLog < ApplicationRecord
   extend T::Sig
 
+  DISCARD_AFTER_MONTHS = 12
+
   sig { returns(T.nilable(String)) }
   attr_reader :ip_address
 

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -8,6 +8,8 @@ require "nokogiri"
 class Domain < ApplicationRecord
   extend T::Sig
 
+  has_many :connection_logs, dependent: :destroy
+
   # If meta is available use that, otherwise title
   sig { returns(T.nilable(String)) }
   def meta_or_title

--- a/app/models/log_line.rb
+++ b/app/models/log_line.rb
@@ -1,7 +1,10 @@
 # typed: strict
 # frozen_string_literal: true
 
-# Output (stdout & stderr) from a scraper
+# Output (stdout & stderr) from a scraper run
 class LogLine < ApplicationRecord
   belongs_to :run
+
+  DISCARD_AFTER_DAYS = 30
+  KEEP_AT_LEAST_COUNT_PER_STATUS = 5
 end

--- a/app/models/log_line.rb
+++ b/app/models/log_line.rb
@@ -6,5 +6,5 @@ class LogLine < ApplicationRecord
   belongs_to :run
 
   DISCARD_AFTER_DAYS = 30
-  KEEP_AT_LEAST_COUNT_PER_STATUS = 5
+  KEEP_AT_LEAST_COUNT_PER_STATUS = 3
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,26 @@ set :repo_url, 'https://github.com/openaustralia/morph.git'
 
 set :rvm_ruby_version, '2.7.6'
 
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
+set :branch, -> {
+  branch = ENV['BRANCH'] || `git rev-parse --abbrev-ref HEAD`.strip
+
+  # Check for uncommitted changes
+  unless `git status --porcelain`.strip.empty?
+    puts "\n⚠️  WARNING: You have uncommitted changes locally"
+  end
+
+  # Check if branch is pushed to origin
+  local_sha = `git rev-parse #{branch}`.strip
+  remote_sha = `git rev-parse origin/#{branch} 2>/dev/null`.strip
+
+  if remote_sha.empty?
+    puts "\n⚠️  WARNING: Branch '#{branch}' doesn't exist on origin"
+  elsif local_sha != remote_sha
+    puts "\n⚠️  WARNING: Branch '#{branch}' is not pushed to origin (or diverged)"
+  end
+
+  branch
+}
 
 set :deploy_to, '/var/www'
 # set :scm, :git

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,14 +11,14 @@ set :branch, -> {
     puts "\n⚠️  WARNING: You have uncommitted changes locally"
   end
 
-  # Check if branch is pushed to origin
+  # Check if branch exists in deployment repo
   local_sha = `git rev-parse #{branch}`.strip
-  remote_sha = `git rev-parse origin/#{branch} 2>/dev/null`.strip
+  remote_sha = `git ls-remote #{fetch(:repo_url)} #{branch} 2>/dev/null`.split.first
 
-  if remote_sha.empty?
-    puts "\n⚠️  WARNING: Branch '#{branch}' doesn't exist on origin"
+  if remote_sha.nil? || remote_sha.strip.empty?
+    puts "⚠️  WARNING: Branch '#{branch}' doesn't exist in #{fetch(:repo_url)}"
   elsif local_sha != remote_sha
-    puts "\n⚠️  WARNING: Branch '#{branch}' is not pushed to origin (or diverged)"
+    puts "⚠️  WARNING: Branch '#{branch}' (commit #{local_sha[0, 9]}) differs from #{fetch(:repo_url)} (commit #{remote_sha[0,9]})"
   end
 
   branch

--- a/config/initializers/app_version.rb
+++ b/config/initializers/app_version.rb
@@ -1,3 +1,4 @@
 unless defined?(APP_VERSION)
-  APP_VERSION = Rails.env.production? ? File.read(File.join(Rails.root, "REVISION"))[0..6] : `git describe --always`
+  revision_file = File.join(Rails.root, "REVISION")
+  APP_VERSION = Rails.env.production? && File.exist?(revision_file) ? File.read(revision_file)[0..6] : `git describe --always`
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -29,4 +29,171 @@ namespace :db do
          "Status as of #{Time.new.utc}",
          ENV["EXACT_COUNT"] ? "(exact count)" : "(approximate count - set EXACT_COUNT=1 to get exact)"
   end
+
+
+  desc "Create a filtered backup of the database"
+  task filtered_backup: :environment do
+    # Setup paths
+    FileUtils.mkdir_p("db/backups")
+    backup_file = Rails.root.join("db/backups/filtered_backup.sql")
+    temp_dir = Rails.root.join("tmp")
+    temp_files = []
+    
+    begin
+      # Dump complete database structure (no data)
+      puts "Dumping complete database structure..."
+      structure_file = temp_dir.join("structure.sql")
+      temp_files << structure_file
+      system_with_time("mysqldump --no-data morph > #{structure_file}")
+      abort "Failed to create #{structure_file}!" unless File.size!(structure_file)
+      
+      # Get filtered owner IDs
+      owner_ids = Owner.where(
+        "name LIKE 'ian%' OR name LIKE 'planningalerts%' OR name LIKE 'mlander%' OR name LIKE 'jame%'"
+      ).pluck(:id)
+      # Add last 20 created owners
+      owner_ids += Owner.order(created_at: :desc).limit(20).pluck(:id)
+      owner_ids.uniq!
+      puts "Found #{owner_ids.count} owners to include"
+      
+      # Dump data for lookup tables (excluding owner-dependent tables - we'll filter those)
+      puts "Dumping lookup tables data..."
+      lookup_file = temp_dir.join("lookup_data.sql")
+      temp_files << lookup_file
+      lookup_tables = %w[
+        active_admin_comments collaborations
+        create_scraper_progresses domains 
+        site_settings variables webhooks
+      ]
+      system_with_time("mysqldump --no-create-info morph #{lookup_tables.join(' ')} > #{lookup_file}")
+      abort "Failed to create #{lookup_file}!" unless File.size!(lookup_file)
+      
+      # Dump filtered owners
+      puts "Dumping filtered owners data..."
+      owners_file = temp_dir.join("owners_data.sql")
+      temp_files << owners_file
+      dump_with_id_batches("owners", "id", owner_ids, owners_file)
+      
+      # Dump owner-dependent tables filtered by owner_id
+      owner_dependent_tables = %w[organizations_users alerts contributions]
+      owner_dependent_tables.each do |table|
+        puts "Dumping filtered #{table} data..."
+        file = temp_dir.join("#{table}_data.sql")
+        temp_files << file
+        dump_with_id_batches(table, "owner_id", owner_ids, file)
+        abort "Failed to create #{file}!" unless File.size!(file)
+      end
+      
+      # Get scraper IDs for filtered owners
+      scraper_ids = Scraper.where(owner_id: owner_ids).pluck(:id)
+      puts "Found #{scraper_ids.count} scrapers to include"
+      
+      # Dump filtered scrapers
+      puts "Dumping filtered scrapers data..."
+      scrapers_file = temp_dir.join("scrapers_data.sql")
+      temp_files << scrapers_file
+      dump_with_id_batches("scrapers", "id", scraper_ids, scrapers_file)
+      abort "Failed to create #{scrapers_file}!" unless File.size!(scrapers_file)
+      
+      # Dump filtered runs and api_queries
+      puts "Dumping filtered runs and api_queries data..."
+      runs_file = temp_dir.join("runs_data.sql")
+      temp_files << runs_file
+      dump_with_id_batches("runs", "scraper_id", scraper_ids, runs_file)
+      abort "Failed to create #{runs_file}!" unless File.size!(runs_file)
+      
+      api_queries_file = temp_dir.join("api_queries_data.sql")
+      temp_files << api_queries_file
+      dump_with_id_batches("api_queries", "scraper_id", scraper_ids, api_queries_file)
+      abort "Failed to create #{api_queries_file}!" unless File.size!(api_queries_file)
+      
+      # Get run IDs for filtered scrapers
+      run_ids = Run.where(scraper_id: scraper_ids).pluck(:id)
+      puts "Found #{run_ids.count} runs to process for related tables"
+      
+      # Dump tables filtered by run_id
+      filtered_runs_file = temp_dir.join("filtered_by_runs.sql")
+      temp_files << filtered_runs_file
+      File.write(filtered_runs_file, "")
+      
+      %w[webhook_deliveries log_lines connection_logs metrics].each do |table|
+        puts "Dumping #{table}..."
+        dump_with_id_batches(table, "run_id", run_ids, filtered_runs_file, append: true)
+      end
+      abort "Failed to create #{filtered_runs_file}!" unless File.size!(filtered_runs_file)
+      
+      # Combine all files
+      puts "Creating final backup..."
+      system("cat #{temp_files.join(' ')} > #{backup_file}")
+      
+      puts "Done! Output in #{backup_file}"
+    ensure
+      # Clean up temp files
+      temp_files.each { |f| File.delete(f) if File.exist?(f) }
+    end
+  end
+
+  namespace :trim do
+    desc "Trim old log lines keeping some for both successful and erroneous runs"
+    task log_lines: :environment do
+      zero_counts = 0
+      total_count = 0
+      puts "Trimming log lines older than #{LogLine::DISCARD_AFTER_DAYS} days,"
+      puts "Keeping at least #{LogLine::KEEP_AT_LEAST_COUNT_PER_STATUS} log lines for both successful and erroneous runs"
+      puts "(progress reported each 50 scrapers, or when log lines are deleted)"
+      Scraper.order(:full_name).each do |scraper|
+        count = scraper.trim_log_lines
+        if count.zero?
+          zero_counts += 1
+          print "."
+          next if zero_counts < 100
+        end
+        zero_counts = 0
+        puts "", "Removed #{count} log lines from #{scraper.full_name}"
+      end
+      puts "", "Removed #{total_count} log lines from #{Scraper.count} scrapers, leaving #{LogLine.count} log lines remaining"
+    end
+  end
+  
+  private
+  
+  def system_with_time(command)
+    start = Time.now
+    result = system(command)
+    puts "  Time: #{(Time.now - start).round(2)}s"
+    result
+  end
+  
+  def dump_with_id_batches(table, column, ids, output_file, append: false)
+    return File.write(output_file, "") if ids.empty? && !append
+    
+    first_batch = !append
+    current_batch = []
+    
+    ids.each do |id|
+      test_batch = current_batch + [id]
+      test_clause = "#{column} in (#{test_batch.join(',')})"
+      
+      # Check if adding this ID would exceed 800 chars
+      if test_clause.length > 800
+        # Dump current batch
+        dump_batch(table, column, current_batch, output_file, first_batch)
+        first_batch = false
+        current_batch = [id]
+      else
+        current_batch << id
+      end
+    end
+    
+    # Dump remaining IDs
+    dump_batch(table, column, current_batch, output_file, first_batch) if current_batch.any?
+  end
+  
+  def dump_batch(table, column, ids, output_file, first_batch)
+    return if ids.empty?
+    
+    ids_list = ids.join(',')
+    redirect = first_batch ? ">" : ">>"
+    system("mysqldump --no-create-info --where=\"#{column} in (#{ids_list})\" morph #{table} #{redirect} #{output_file}")
+  end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -49,7 +49,7 @@ namespace :db do
       
       # Get filtered owner IDs
       owner_ids = Owner.where(
-        "name LIKE 'ian%' OR name LIKE 'planningalerts%' OR name LIKE 'mlander%' OR name LIKE 'jame%'"
+        "name LIKE 'ian%' OR name LIKE 'planning%' OR name LIKE 'mlander%' OR name LIKE 'openaust%' OR name LIKE 'jame%'"
       ).pluck(:id)
       # Add last 20 created owners
       owner_ids += Owner.order(created_at: :desc).limit(20).pluck(:id)


### PR DESCRIPTION
Trim log_lines table - to clean up old run logs, related issue:
* https://github.com/openaustralia/morph/issues/1373
