### PR TITLE
Fix deploy branch or current branch rather than default non existent master [superseded]

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,14 +11,14 @@ set :branch, -> {
     puts "\n⚠️  WARNING: You have uncommitted changes locally"
   end
 
-  # Check if branch is pushed to origin
+  # Check if branch exists in deployment repo
   local_sha = `git rev-parse #{branch}`.strip
-  remote_sha = `git rev-parse origin/#{branch} 2>/dev/null`.strip
+  remote_sha = `git ls-remote #{fetch(:repo_url)} #{branch} 2>/dev/null`.split.first
 
-  if remote_sha.empty?
-    puts "\n⚠️  WARNING: Branch '#{branch}' doesn't exist on origin"
+  if remote_sha.nil? || remote_sha.strip.empty?
+    puts "⚠️  WARNING: Branch '#{branch}' doesn't exist in #{fetch(:repo_url)}"
   elsif local_sha != remote_sha
-    puts "\n⚠️  WARNING: Branch '#{branch}' is not pushed to origin (or diverged)"
+    puts "⚠️  WARNING: Branch '#{branch}' (commit #{local_sha[0, 9]}) differs from #{fetch(:repo_url)} (commit #{remote_sha[0,9]})"
   end
 
   branch

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,14 +11,14 @@ set :branch, -> {
     puts "\n⚠️  WARNING: You have uncommitted changes locally"
   end
 
-  # Check if branch exists in deployment repo
+  # Check if branch is pushed to origin
   local_sha = `git rev-parse #{branch}`.strip
-  remote_sha = `git ls-remote #{fetch(:repo_url)} #{branch} 2>/dev/null`.split.first
+  remote_sha = `git rev-parse origin/#{branch} 2>/dev/null`.strip
 
-  if remote_sha.nil? || remote_sha.strip.empty?
-    puts "⚠️  WARNING: Branch '#{branch}' doesn't exist in #{fetch(:repo_url)}"
+  if remote_sha.empty?
+    puts "\n⚠️  WARNING: Branch '#{branch}' doesn't exist on origin"
   elsif local_sha != remote_sha
-    puts "⚠️  WARNING: Branch '#{branch}' (commit #{local_sha[0, 9]}) differs from #{fetch(:repo_url)} (commit #{remote_sha[0,9]})"
+    puts "\n⚠️  WARNING: Branch '#{branch}' is not pushed to origin (or diverged)"
   end
 
   branch


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/morph/issues/1386
* https://github.com/openaustralia/morph/issues/1383

## What does this do?

Deploy $BRANCH or current branch

## Why was this needed?

This fixes capistrano defaulting to master, which no longer exists, and deploys the repo you are deploying from rather than assuming the current branch commit is present in OAF repo

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

This was used to deploy the release_candidate branch to the production server (release_candidate is based on production branch, which is what production had previously).

Review and merge these PRs first:
* https://github.com/openaustralia/morph/pull/1384 (merged to release_candidate)
* https://github.com/openaustralia/morph/pull/1396