### PR TITLE
Annotate models and related specs with their schema chore for rails 6.0

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,0 +1,61 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: false
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:timestamp_columns:
+- created_at
+- updated_at
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ group :development do
   gem "rack-mini-profiler"
   # gem "flamegraph"
 
-  gem 'annotaterb', '~> 4.15.0' # 4.16+ requires ruby 3.0
+  gem "annotaterb", "~> 4.15.0" # 4.16+ requires ruby 3.0
   gem "better_errors"
   gem "binding_of_caller"
   gem "memory_profiler"
@@ -211,4 +211,3 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
-

--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,7 @@ group :development do
   gem "rack-mini-profiler"
   # gem "flamegraph"
 
+  gem 'annotaterb', '~> 4.15.0' # 4.16+ requires ruby 3.0
   gem "better_errors"
   gem "binding_of_caller"
   gem "memory_profiler"
@@ -210,3 +211,4 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    annotaterb (4.15.0)
     ansi (1.5.0)
     arbre (1.5.0)
       activesupport (>= 3.0.0, < 7.1)
@@ -690,6 +691,7 @@ PLATFORMS
 DEPENDENCIES
   RedCloth
   activeadmin
+  annotaterb (~> 4.15.0)
   archive-tar-minitar
   backstretch-rails
   bcrypt_pbkdf (~> 1.1)

--- a/app/lib/morph/docker_utils.rb
+++ b/app/lib/morph/docker_utils.rb
@@ -257,7 +257,7 @@ module Morph
       base_layer_index = layers.find_index { |l| l["Id"] == image_base.id }
       raise "image is not built on top of image_base" if base_layer_index.nil?
 
-      diff_layers = layers[0..base_layer_index - 1]
+      diff_layers = layers[0..(base_layer_index - 1)]
       diff_layers.map { |l| l["Size"] }.sum
     end
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -2,6 +2,23 @@
 # frozen_string_literal: true
 
 # A user watching something - can be a scraper, a user or an org
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id         :integer          not null, primary key
+#  watch_type :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#  user_id    :integer
+#  watch_id   :integer
+#
+# Indexes
+#
+#  index_alerts_on_user_id     (user_id)
+#  index_alerts_on_watch_id    (watch_id)
+#  index_alerts_on_watch_type  (watch_type)
+#
 class Alert < ApplicationRecord
   belongs_to :watch, polymorphic: true
   belongs_to :user

--- a/app/models/api_query.rb
+++ b/app/models/api_query.rb
@@ -2,6 +2,33 @@
 # frozen_string_literal: true
 
 # A record of a download or an API query
+# == Schema Information
+#
+# Table name: api_queries
+#
+#  id         :integer          not null, primary key
+#  format     :string(255)
+#  query      :text(65535)
+#  size       :integer
+#  stime      :float(24)
+#  type       :string(255)
+#  utime      :float(24)
+#  wall_time  :float(24)
+#  created_at :datetime
+#  updated_at :datetime
+#  owner_id   :integer
+#  scraper_id :integer
+#
+# Indexes
+#
+#  index_api_queries_on_created_at  (created_at)
+#  index_api_queries_on_owner_id    (owner_id)
+#  index_api_queries_on_scraper_id  (scraper_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 class ApiQuery < ApplicationRecord
   extend T::Sig
   belongs_to :scraper

--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -2,6 +2,32 @@
 # frozen_string_literal: true
 
 # Contribution of a user to the code a scraper
+# == Schema Information
+#
+# Table name: collaborations
+#
+#  id         :bigint           not null, primary key
+#  admin      :boolean          not null
+#  maintain   :boolean          not null
+#  pull       :boolean          not null
+#  push       :boolean          not null
+#  triage     :boolean          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  owner_id   :integer          not null
+#  scraper_id :integer          not null
+#
+# Indexes
+#
+#  index_collaborations_on_owner_id                 (owner_id)
+#  index_collaborations_on_scraper_id               (scraper_id)
+#  index_collaborations_on_scraper_id_and_owner_id  (scraper_id,owner_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (owner_id => owners.id)
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 class Collaboration < ApplicationRecord
   belongs_to :owner
   belongs_to :scraper

--- a/app/models/connection_log.rb
+++ b/app/models/connection_log.rb
@@ -2,6 +2,26 @@
 # frozen_string_literal: true
 
 # A record of an http/https request from a scraper to the outside world
+# == Schema Information
+#
+# Table name: connection_logs
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  domain_id  :integer
+#  run_id     :integer
+#
+# Indexes
+#
+#  index_connection_logs_on_created_at  (created_at)
+#  index_connection_logs_on_domain_id   (domain_id)
+#  index_connection_logs_on_run_id      (run_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (domain_id => domains.id)
+#  fk_rails_...  (run_id => runs.id)
+#
 class ConnectionLog < ApplicationRecord
   extend T::Sig
 

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -2,6 +2,25 @@
 # frozen_string_literal: true
 
 # Contribution of a user to the code a scraper
+# == Schema Information
+#
+# Table name: contributions
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  updated_at :datetime
+#  scraper_id :integer
+#  user_id    :integer
+#
+# Indexes
+#
+#  index_contributions_on_scraper_id  (scraper_id)
+#  index_contributions_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 class Contribution < ApplicationRecord
   belongs_to :user
   belongs_to :scraper

--- a/app/models/create_scraper_progress.rb
+++ b/app/models/create_scraper_progress.rb
@@ -2,6 +2,17 @@
 # frozen_string_literal: true
 
 # Progress in morp creating a scraper
+# == Schema Information
+#
+# Table name: create_scraper_progresses
+#
+#  id         :integer          not null, primary key
+#  heading    :string(255)
+#  message    :string(255)
+#  progress   :integer
+#  created_at :datetime
+#  updated_at :datetime
+#
 class CreateScraperProgress < ApplicationRecord
   extend T::Sig
 

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -2,6 +2,21 @@
 # frozen_string_literal: true
 
 # For the benefit of UpdateDomainWorker
+# == Schema Information
+#
+# Table name: domains
+#
+#  id         :integer          not null, primary key
+#  meta       :text(65535)
+#  name       :string(255)      default(""), not null
+#  title      :text(65535)
+#  created_at :datetime
+#  updated_at :datetime
+#
+# Indexes
+#
+#  index_domains_on_name  (name) UNIQUE
+#
 require "nokogiri"
 
 # A domain that is scraped by a scraper

--- a/app/models/log_line.rb
+++ b/app/models/log_line.rb
@@ -2,6 +2,27 @@
 # frozen_string_literal: true
 
 # Output (stdout & stderr) from a scraper run
+# == Schema Information
+#
+# Table name: log_lines
+#
+#  id         :integer          not null, primary key
+#  stream     :string(255)
+#  text       :text(65535)
+#  timestamp  :datetime
+#  created_at :datetime
+#  updated_at :datetime
+#  run_id     :integer
+#
+# Indexes
+#
+#  index_log_lines_on_run_id     (run_id)
+#  index_log_lines_on_timestamp  (timestamp)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (run_id => runs.id)
+#
 class LogLine < ApplicationRecord
   belongs_to :run
 

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -2,6 +2,33 @@
 # frozen_string_literal: true
 
 # Capture output of /usr/bin/time command (on Linux)
+# == Schema Information
+#
+# Table name: metrics
+#
+#  id         :integer          not null, primary key
+#  inblock    :integer
+#  majflt     :integer
+#  maxrss     :integer
+#  minflt     :integer
+#  nivcsw     :integer
+#  nvcsw      :integer
+#  oublock    :integer
+#  stime      :float(24)
+#  utime      :float(24)
+#  wall_time  :float(24)
+#  created_at :datetime
+#  updated_at :datetime
+#  run_id     :integer
+#
+# Indexes
+#
+#  index_metrics_on_run_id  (run_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (run_id => runs.id)
+#
 class Metric < ApplicationRecord
   extend T::Sig
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,6 +2,45 @@
 # frozen_string_literal: true
 
 # Using American spelling to match GitHub usage
+# == Schema Information
+#
+# Table name: owners
+#
+#  id                     :integer          not null, primary key
+#  access_token           :string(255)
+#  admin                  :boolean          default(FALSE), not null
+#  alerted_at             :datetime
+#  api_key                :string(255)
+#  blog                   :string(255)
+#  company                :string(255)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string(255)
+#  email                  :string(255)
+#  feature_switches       :string(255)
+#  gravatar_url           :string(255)
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string(255)
+#  location               :string(255)
+#  name                   :string(255)
+#  nickname               :string(255)
+#  provider               :string(255)
+#  remember_created_at    :datetime
+#  remember_token         :string(255)
+#  sign_in_count          :integer          default(0), not null
+#  suspended              :boolean          default(FALSE), not null
+#  type                   :string(255)
+#  uid                    :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  stripe_customer_id     :string(255)
+#  stripe_plan_id         :string(255)
+#  stripe_subscription_id :string(255)
+#
+# Indexes
+#
+#  index_owners_on_api_key   (api_key)
+#  index_owners_on_nickname  (nickname)
+#
 class Organization < Owner
   extend T::Sig
 

--- a/app/models/organizations_user.rb
+++ b/app/models/organizations_user.rb
@@ -1,6 +1,19 @@
 # typed: strict
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organizations_users
+#
+#  id              :integer          not null, primary key
+#  organization_id :integer
+#  user_id         :integer
+#
+# Indexes
+#
+#  index_organizations_users_on_organization_id  (organization_id)
+#  index_organizations_users_on_user_id          (user_id)
+#
 class OrganizationsUser < ApplicationRecord
   belongs_to :organization
   belongs_to :user

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -2,6 +2,45 @@
 # frozen_string_literal: true
 
 # A user or organization that a scraper belongs to
+# == Schema Information
+#
+# Table name: owners
+#
+#  id                     :integer          not null, primary key
+#  access_token           :string(255)
+#  admin                  :boolean          default(FALSE), not null
+#  alerted_at             :datetime
+#  api_key                :string(255)
+#  blog                   :string(255)
+#  company                :string(255)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string(255)
+#  email                  :string(255)
+#  feature_switches       :string(255)
+#  gravatar_url           :string(255)
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string(255)
+#  location               :string(255)
+#  name                   :string(255)
+#  nickname               :string(255)
+#  provider               :string(255)
+#  remember_created_at    :datetime
+#  remember_token         :string(255)
+#  sign_in_count          :integer          default(0), not null
+#  suspended              :boolean          default(FALSE), not null
+#  type                   :string(255)
+#  uid                    :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  stripe_customer_id     :string(255)
+#  stripe_plan_id         :string(255)
+#  stripe_subscription_id :string(255)
+#
+# Indexes
+#
+#  index_owners_on_api_key   (api_key)
+#  index_owners_on_nickname  (nickname)
+#
 class Owner < ApplicationRecord
   extend T::Sig
   extend T::Helpers

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -2,6 +2,49 @@
 # frozen_string_literal: true
 
 # A run of a scraper
+# == Schema Information
+#
+# Table name: runs
+#
+#  id                    :integer          not null, primary key
+#  auto                  :boolean          default(FALSE), not null
+#  connection_logs_count :integer
+#  docker_image          :string(255)
+#  finished_at           :datetime
+#  git_revision          :string(255)
+#  ip_address            :string(255)
+#  queued_at             :datetime
+#  records_added         :integer
+#  records_changed       :integer
+#  records_removed       :integer
+#  records_unchanged     :integer
+#  started_at            :datetime
+#  status_code           :integer
+#  tables_added          :integer
+#  tables_changed        :integer
+#  tables_removed        :integer
+#  tables_unchanged      :integer
+#  wall_time             :float(24)        default(0.0), not null
+#  created_at            :datetime
+#  updated_at            :datetime
+#  owner_id              :integer          not null
+#  scraper_id            :integer
+#
+# Indexes
+#
+#  index_runs_on_created_at                                  (created_at)
+#  index_runs_on_docker_image                                (docker_image)
+#  index_runs_on_finished_at                                 (finished_at)
+#  index_runs_on_ip_address                                  (ip_address)
+#  index_runs_on_owner_id                                    (owner_id)
+#  index_runs_on_scraper_id                                  (scraper_id)
+#  index_runs_on_scraper_id_and_status_code_and_finished_at  (scraper_id,status_code,finished_at)
+#  index_runs_on_started_at                                  (started_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 class Run < ApplicationRecord
   extend T::Sig
 

--- a/app/models/scraper.rb
+++ b/app/models/scraper.rb
@@ -2,6 +2,41 @@
 # frozen_string_literal: true
 
 # A scraper is a script that runs that gets data from the web
+# == Schema Information
+#
+# Table name: scrapers
+#
+#  id                         :integer          not null, primary key
+#  auto_run                   :boolean          default(FALSE), not null
+#  description                :string(255)
+#  full_name                  :string(255)      not null
+#  git_url                    :string(255)
+#  github_url                 :string(255)
+#  memory_mb                  :integer
+#  name                       :string(255)      default(""), not null
+#  original_language_key      :string(255)
+#  private                    :boolean          default(FALSE), not null
+#  repo_size                  :integer          default(0), not null
+#  scraperwiki_url            :string(255)
+#  sqlite_db_size             :bigint           default(0), not null
+#  created_at                 :datetime
+#  updated_at                 :datetime
+#  create_scraper_progress_id :integer
+#  forked_by_id               :integer
+#  github_id                  :integer
+#  owner_id                   :integer          not null
+#
+# Indexes
+#
+#  fk_rails_44c3dd8af8                  (create_scraper_progress_id)
+#  index_scrapers_on_full_name          (full_name) UNIQUE
+#  index_scrapers_on_owner_id           (owner_id)
+#  index_scrapers_on_owner_id_and_name  (owner_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (create_scraper_progress_id => create_scraper_progresses.id)
+#
 class Scraper < ApplicationRecord
   extend T::Sig
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,6 +1,15 @@
 # typed: strict
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: site_settings
+#
+#  id         :integer          not null, primary key
+#  settings   :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#
 require "sorbet-runtime"
 
 # Settings that apply to the whole app and everybody on it

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,45 @@
 # frozen_string_literal: true
 
 # A real human being (hopefully)
+# == Schema Information
+#
+# Table name: owners
+#
+#  id                     :integer          not null, primary key
+#  access_token           :string(255)
+#  admin                  :boolean          default(FALSE), not null
+#  alerted_at             :datetime
+#  api_key                :string(255)
+#  blog                   :string(255)
+#  company                :string(255)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string(255)
+#  email                  :string(255)
+#  feature_switches       :string(255)
+#  gravatar_url           :string(255)
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string(255)
+#  location               :string(255)
+#  name                   :string(255)
+#  nickname               :string(255)
+#  provider               :string(255)
+#  remember_created_at    :datetime
+#  remember_token         :string(255)
+#  sign_in_count          :integer          default(0), not null
+#  suspended              :boolean          default(FALSE), not null
+#  type                   :string(255)
+#  uid                    :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  stripe_customer_id     :string(255)
+#  stripe_plan_id         :string(255)
+#  stripe_subscription_id :string(255)
+#
+# Indexes
+#
+#  index_owners_on_api_key   (api_key)
+#  index_owners_on_nickname  (nickname)
+#
 class User < Owner
   extend T::Sig
 

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -2,6 +2,25 @@
 # frozen_string_literal: true
 
 # A secret environment variable and its value that can be passed to a scraper
+# == Schema Information
+#
+# Table name: variables
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)      not null
+#  value      :text(65535)      not null
+#  created_at :datetime
+#  updated_at :datetime
+#  scraper_id :integer
+#
+# Indexes
+#
+#  fk_rails_f537200e37  (scraper_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 class Variable < ApplicationRecord
   extend T::Sig
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,6 +1,25 @@
 # typed: strict
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: webhooks
+#
+#  id         :integer          not null, primary key
+#  url        :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#  scraper_id :integer
+#
+# Indexes
+#
+#  index_webhooks_on_scraper_id          (scraper_id)
+#  index_webhooks_on_scraper_id_and_url  (scraper_id,url) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 class Webhook < ApplicationRecord
   extend T::Sig
 

--- a/app/models/webhook_delivery.rb
+++ b/app/models/webhook_delivery.rb
@@ -1,6 +1,28 @@
 # typed: strict
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: webhook_deliveries
+#
+#  id            :integer          not null, primary key
+#  response_code :integer
+#  sent_at       :datetime
+#  created_at    :datetime
+#  updated_at    :datetime
+#  run_id        :integer
+#  webhook_id    :integer
+#
+# Indexes
+#
+#  index_webhook_deliveries_on_run_id      (run_id)
+#  index_webhook_deliveries_on_webhook_id  (webhook_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (run_id => runs.id)
+#  fk_rails_...  (webhook_id => webhooks.id)
+#
 class WebhookDelivery < ApplicationRecord
   extend T::Sig
   SUCCESSFUL_STATUSES = T.let((200..299).freeze, T::Range[Integer])

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,3 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
 # This rake task was added by annotate_rb gem.
 
 # Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this

--- a/spec/models/connection_log_spec.rb
+++ b/spec/models/connection_log_spec.rb
@@ -1,6 +1,26 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: connection_logs
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  domain_id  :integer
+#  run_id     :integer
+#
+# Indexes
+#
+#  index_connection_logs_on_created_at  (created_at)
+#  index_connection_logs_on_domain_id   (domain_id)
+#  index_connection_logs_on_run_id      (run_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (domain_id => domains.id)
+#  fk_rails_...  (run_id => runs.id)
+#
 require "spec_helper"
 
 describe ConnectionLog do

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,6 +1,21 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: domains
+#
+#  id         :integer          not null, primary key
+#  meta       :text(65535)
+#  name       :string(255)      default(""), not null
+#  title      :text(65535)
+#  created_at :datetime
+#  updated_at :datetime
+#
+# Indexes
+#
+#  index_domains_on_name  (name) UNIQUE
+#
 require "spec_helper"
 
 describe Domain do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -1,6 +1,49 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: runs
+#
+#  id                    :integer          not null, primary key
+#  auto                  :boolean          default(FALSE), not null
+#  connection_logs_count :integer
+#  docker_image          :string(255)
+#  finished_at           :datetime
+#  git_revision          :string(255)
+#  ip_address            :string(255)
+#  queued_at             :datetime
+#  records_added         :integer
+#  records_changed       :integer
+#  records_removed       :integer
+#  records_unchanged     :integer
+#  started_at            :datetime
+#  status_code           :integer
+#  tables_added          :integer
+#  tables_changed        :integer
+#  tables_removed        :integer
+#  tables_unchanged      :integer
+#  wall_time             :float(24)        default(0.0), not null
+#  created_at            :datetime
+#  updated_at            :datetime
+#  owner_id              :integer          not null
+#  scraper_id            :integer
+#
+# Indexes
+#
+#  index_runs_on_created_at                                  (created_at)
+#  index_runs_on_docker_image                                (docker_image)
+#  index_runs_on_finished_at                                 (finished_at)
+#  index_runs_on_ip_address                                  (ip_address)
+#  index_runs_on_owner_id                                    (owner_id)
+#  index_runs_on_scraper_id                                  (scraper_id)
+#  index_runs_on_scraper_id_and_status_code_and_finished_at  (scraper_id,status_code,finished_at)
+#  index_runs_on_started_at                                  (started_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 require "spec_helper"
 
 describe Run do

--- a/spec/models/scraper_spec.rb
+++ b/spec/models/scraper_spec.rb
@@ -1,6 +1,41 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: scrapers
+#
+#  id                         :integer          not null, primary key
+#  auto_run                   :boolean          default(FALSE), not null
+#  description                :string(255)
+#  full_name                  :string(255)      not null
+#  git_url                    :string(255)
+#  github_url                 :string(255)
+#  memory_mb                  :integer
+#  name                       :string(255)      default(""), not null
+#  original_language_key      :string(255)
+#  private                    :boolean          default(FALSE), not null
+#  repo_size                  :integer          default(0), not null
+#  scraperwiki_url            :string(255)
+#  sqlite_db_size             :bigint           default(0), not null
+#  created_at                 :datetime
+#  updated_at                 :datetime
+#  create_scraper_progress_id :integer
+#  forked_by_id               :integer
+#  github_id                  :integer
+#  owner_id                   :integer          not null
+#
+# Indexes
+#
+#  fk_rails_44c3dd8af8                  (create_scraper_progress_id)
+#  index_scrapers_on_full_name          (full_name) UNIQUE
+#  index_scrapers_on_owner_id           (owner_id)
+#  index_scrapers_on_owner_id_and_name  (owner_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (create_scraper_progress_id => create_scraper_progresses.id)
+#
 require "spec_helper"
 
 describe Scraper do

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -1,6 +1,15 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: site_settings
+#
+#  id         :integer          not null, primary key
+#  settings   :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#
 require "spec_helper"
 
 describe SiteSetting do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,45 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: owners
+#
+#  id                     :integer          not null, primary key
+#  access_token           :string(255)
+#  admin                  :boolean          default(FALSE), not null
+#  alerted_at             :datetime
+#  api_key                :string(255)
+#  blog                   :string(255)
+#  company                :string(255)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string(255)
+#  email                  :string(255)
+#  feature_switches       :string(255)
+#  gravatar_url           :string(255)
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string(255)
+#  location               :string(255)
+#  name                   :string(255)
+#  nickname               :string(255)
+#  provider               :string(255)
+#  remember_created_at    :datetime
+#  remember_token         :string(255)
+#  sign_in_count          :integer          default(0), not null
+#  suspended              :boolean          default(FALSE), not null
+#  type                   :string(255)
+#  uid                    :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  stripe_customer_id     :string(255)
+#  stripe_plan_id         :string(255)
+#  stripe_subscription_id :string(255)
+#
+# Indexes
+#
+#  index_owners_on_api_key   (api_key)
+#  index_owners_on_nickname  (nickname)
+#
 require "spec_helper"
 
 describe User do

--- a/spec/models/variable_spec.rb
+++ b/spec/models/variable_spec.rb
@@ -1,6 +1,25 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: variables
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)      not null
+#  value      :text(65535)      not null
+#  created_at :datetime
+#  updated_at :datetime
+#  scraper_id :integer
+#
+# Indexes
+#
+#  fk_rails_f537200e37  (scraper_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 require "spec_helper"
 
 describe Variable do

--- a/spec/models/webhook_delivery_spec.rb
+++ b/spec/models/webhook_delivery_spec.rb
@@ -1,6 +1,28 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: webhook_deliveries
+#
+#  id            :integer          not null, primary key
+#  response_code :integer
+#  sent_at       :datetime
+#  created_at    :datetime
+#  updated_at    :datetime
+#  run_id        :integer
+#  webhook_id    :integer
+#
+# Indexes
+#
+#  index_webhook_deliveries_on_run_id      (run_id)
+#  index_webhook_deliveries_on_webhook_id  (webhook_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (run_id => runs.id)
+#  fk_rails_...  (webhook_id => webhooks.id)
+#
 require "spec_helper"
 
 RSpec.describe WebhookDelivery, type: :model do

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -1,6 +1,25 @@
 # typed: false
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: webhooks
+#
+#  id         :integer          not null, primary key
+#  url        :string(255)
+#  created_at :datetime
+#  updated_at :datetime
+#  scraper_id :integer
+#
+# Indexes
+#
+#  index_webhooks_on_scraper_id          (scraper_id)
+#  index_webhooks_on_scraper_id_and_url  (scraper_id,url) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (scraper_id => scrapers.id)
+#
 require "spec_helper"
 
 RSpec.describe Webhook, type: :model do


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/morph/issues/1410
* https://github.com/openaustralia/morph/issues/1353 (parent)

## What does this do?

Automatically annotate models with a comment summarizing their current schema when db:migrate runs

## Why was this needed?

Speeds up development

## Implementation/Deploy Steps

None - runs automatically whenever `rake db:migrate` is run and checks modems and specs are up to date

