### PR TITLE
Separate logs by service [Merge Round 1]

### DIFF
--- a/provisioning/roles/discourse/templates/discourse.nginx
+++ b/provisioning/roles/discourse/templates/discourse.nginx
@@ -1,6 +1,8 @@
 server {
   listen 443;
   server_name {{ discourse_server_name }};
+  access_log /var/log/nginx/help.access.log;
+  error_log /var/log/nginx/help.error.log;
 
   ssl on;
   ssl_certificate /etc/letsencrypt/live/{{ server_name }}/fullchain.pem; # managed by Certbot

--- a/provisioning/roles/morph-app/templates/sites/default
+++ b/provisioning/roles/morph-app/templates/sites/default
@@ -2,4 +2,6 @@
 server {
   listen 80 default_server;
   return 301 https://{{ server_name }}$request_uri;
+  access_log /var/log/nginx/default.access.log;
+  error_log /var/log/nginx/default.error.log;
 }

--- a/provisioning/roles/morph-app/templates/sites/faye.morph.io
+++ b/provisioning/roles/morph-app/templates/sites/faye.morph.io
@@ -5,6 +5,8 @@ upstream faye_backend {
 server {
   listen 443;
   server_name faye.{{ server_name }};
+  access_log /var/log/nginx/faye.access.log;
+  error_log /var/log/nginx/faye.error.log;
 
   ssl on;
   ssl_certificate /etc/letsencrypt/live/{{ server_name }}/fullchain.pem; # managed by Certbot

--- a/provisioning/roles/morph-app/templates/sites/morph.io
+++ b/provisioning/roles/morph-app/templates/sites/morph.io
@@ -1,6 +1,8 @@
 server {
   listen 443;
   server_name {{ server_name }} api.{{ server_name }};
+  access_log /var/log/nginx/morph.access.log;
+  error_log /var/log/nginx/morph.error.log;
   root /var/www/current/public;
   passenger_enabled on;
   passenger_ruby /home/deploy/.rvm/gems/ruby-{{ ruby_version }}/wrappers/ruby;


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/morph/issues/1419

## What does this do?

Provides Separate logs for different host names to make devops easier

## Why was this needed?

 I was struggling to see the trees for the blizzard of door knocking scans from bots

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

See extra files in /var/log/nginx by site

logrotate should rotate the extra log files as well
