### PR TITLE
Bugfix limit_output status on bad arguments for rails 6.0

### DIFF
--- a/lib/morph/limit_output.rb
+++ b/lib/morph/limit_output.rb
@@ -19,14 +19,14 @@ OptionParser.new do |opts|
   if ARGV[0].nil?
     STDERR.puts "Please give me the maximum number of lines of output to show"
     puts opts
-    exit
+    exit(1)
   end
 
   command = ARGV[1]
   if command.nil?
     STDERR.puts "Please give me a command to run"
     puts opts
-    exit
+    exit(1)
   end
 end.parse!
 

--- a/spec/morph/limit_output_spec.rb
+++ b/spec/morph/limit_output_spec.rb
@@ -1,0 +1,71 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "open3"
+
+describe "lib/morph/limit_output.rb" do # rubocop:disable RSpec/DescribeClass
+  let(:script_path) { Rails.root.join("lib/morph/limit_output.rb") }
+
+  it "passes through output under the limit" do
+    stdout, stderr, status = Open3.capture3(
+      "ruby", script_path.to_s, "10", "echo 'hello world'"
+    )
+    expect(stdout).to eq("hello world\n")
+    expect(stderr).to be_empty
+    expect(status.exitstatus).to eq(0)
+  end
+
+  it "truncates output over the limit" do
+    command = "ruby -e '5.times { puts \"line\" }'"
+    stdout, stderr, status = Open3.capture3(
+      "ruby", script_path.to_s, "3", command
+    )
+    expect(stdout.lines.count).to eq(3)
+    expect(stderr).to include("Too many lines of output!")
+    expect(status.exitstatus).to eq(0)
+  end
+
+  it "allows unlimited output when limit is 0" do
+    command = "ruby -e '100.times { puts \"line\" }'"
+    stdout, stderr, status = Open3.capture3(
+      "ruby", script_path.to_s, "0", command
+    )
+    expect(stdout.lines.count).to eq(100)
+    expect(stderr).to be_empty
+    expect(status.exitstatus).to eq(0)
+  end
+
+  it "preserves command exit status" do
+    _stdout, _stderr, status = Open3.capture3(
+      "ruby", script_path.to_s, "10", "ruby -e 'exit 42'"
+    )
+    expect(status.exitstatus).to eq(42)
+  end
+
+  it "handles stderr output" do
+    command = "ruby -e 'STDERR.puts \"error message\"'"
+    stdout, stderr, status = Open3.capture3(
+      "ruby", script_path.to_s, "10", command
+    )
+    expect(stdout).to be_empty
+    expect(stderr).to eq("error message\n")
+    expect(status.exitstatus).to eq(0)
+  end
+
+  it "exits with error when max_lines not provided" do
+    _, stderr, status = Open3.capture3(
+      "ruby", script_path.to_s
+    )
+    expect(stderr).to include("Please give me the maximum number of lines")
+    expect(status.exitstatus).not_to eq(0)
+  end
+
+  it "exits with error when command not provided" do
+    _, stderr, status = Open3.capture3(
+      "ruby", script_path.to_s, "10"
+    )
+    expect(stderr).to include("Please give me a command to run")
+    expect(status.exitstatus).not_to eq(0)
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/morph/issues/1353

## What does this do?

Tests limit_output script and sets exit status to 1 if the arguments are bad

## Why was this needed?

Fix problems when you notice them so they don't get forgotton
