### PR TITLE
Mark more tests as slow and run all tests on github [Merge round 1]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -89,7 +89,7 @@ jobs:
         run: bundle exec rails db:create db:migrate
 
       - name: Run rspec
-        run: DONT_RUN_DOCKER_TESTS=1 bundle exec rspec spec -fd
+        run: DONT_RUN_DOCKER_TESTS=1 RUN_SLOW_TESTS=1 bundle exec rspec spec -fd
       
       - uses: qltysh/qlty-action/coverage@v1
         with:

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--profile

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,15 @@ services-logs: ## View logs for services (use SERVICES=elasticsearch for specifi
 services-status: ## Check status of services
 	COMPOSE_PROJECT_NAME=morph-services docker compose -f docker_images/services.yaml ps
 
-test: ## Run rspec tests (Optionally add RUN_SLOW_TESTS=1 or DONT_RUN_DOCKER_TESTS=1)
+rspec: ## Run all rspec tests (Optionally add DONT_RUN_SLOW_TESTS=1 or DONT_RUN_DOCKER_TESTS=1 or DONT_RUN_GITHUB_TESTS=1)
 	RAILS_ENV=test bundle exec rspec
+
+test: quick-tests ## Run quick test then everything for a full coverage/index.html report
+	RUN_SLOW_TESTS=1 bundle exec rake
+	echo Passed all tests!
+
+quick-tests: ## Run quick rspec tests (excludes slow, docker and github tests)
+	DONT_RUN_GITHUB_TESTS=1 DONT_RUN_DOCKER_TESTS=1 bundle exec rake
 
 lint: ## Lint code
 	bundle exec rubocop

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
         production-deploy production-provision provision \
         roles services-down services-up \
 	staging-anible staging-deploy staging-provision \
-        share-web test up vagrant-plugins venv
+        share-web test up vagrant-plugins venv \
+	all-tests quick-tests
 VENV := .venv/bin
 SHELL := /bin/bash
 PYTHON_VERSION := $(shell cat .python-version 2>/dev/null || echo "python3")
@@ -118,12 +119,15 @@ services-status: ## Check status of services
 rspec: ## Run all rspec tests (Optionally add DONT_RUN_SLOW_TESTS=1 or DONT_RUN_DOCKER_TESTS=1 or DONT_RUN_GITHUB_TESTS=1)
 	RAILS_ENV=test bundle exec rspec
 
-test: quick-tests ## Run quick test then everything for a full coverage/index.html report
-	RUN_SLOW_TESTS=1 bundle exec rake
-	echo Passed all tests!
+test: quick-tests all-tests ## Run quick test then everything for a full coverage/index.html report
 
 quick-tests: ## Run quick rspec tests (excludes slow, docker and github tests)
 	DONT_RUN_GITHUB_TESTS=1 DONT_RUN_DOCKER_TESTS=1 bundle exec rake
+	echo "Passed quick tests!"
+
+all-tests: ## Run all rspec tests
+	RUN_SLOW_TESTS=1 bundle exec rake
+	echo "Passed all tests!"
 
 lint: ## Lint code
 	bundle exec rubocop

--- a/TESTING.md
+++ b/TESTING.md
@@ -20,10 +20,15 @@ You can force the test to be excluded by setting
 
     DONT_RUN_GITHUB_TESTS=1
 
+For convenience, use the following command to run the quick tests first to see if something obviously broke, then run
+the full suite:
+
+    make test
+
 Manual Tests
 ------------    
 
-Tests that require a lot of setup have been left for manual testing. 
+Tests that require a lot of setup have been left for manual testing.
 Search for `# :nocov:` in the code to find code that needs manual testing.
 This includes:
 

--- a/app/views/scrapers/_scraper_created_history_item.html.haml
+++ b/app/views/scrapers/_scraper_created_history_item.html.haml
@@ -1,3 +1,3 @@
 %li.list-group-item
-  Created on { hostname }
+  Created on #{hostname}
   = timeago_tag(scraper.created_at, force: true)

--- a/spec/integration/hardcoded_domain_spec.rb
+++ b/spec/integration/hardcoded_domain_spec.rb
@@ -140,12 +140,12 @@ describe "Hardcoded domain references", type: :request do
         html.gsub!(legit_reference, "")
       end
 
-      next unless html.include?("morph.io")
+      next unless html.include?("morph.io") || html.include?("hostname")
 
       # Find context around each occurrence
       matches = []
-      html.scan(/.{0,80}morph\.io.{0,80}/m) do |match|
-        matches << match.gsub(/\s+/, " ").strip
+      html.scan(/(.{0,80}(morph\.io|hostname).{0,80})/m) do |match|
+        matches << match[0].gsub(/\s+/, " ").strip
       end
 
       violations[path] = matches if matches.any?

--- a/spec/integration/hardcoded_domain_spec.rb
+++ b/spec/integration/hardcoded_domain_spec.rb
@@ -97,7 +97,7 @@ describe "Hardcoded domain references", type: :request do
     sign_in admin
   end
 
-  it "uses hostname helper instead of hardcoded morph.io" do
+  it "uses hostname helper instead of hardcoded morph.io (also smoke tests most GET routes)", slow: true do # 37 seconds
     routes = Rails.application.routes.routes
                   .select { |r| r.verb =~ /GET/ }
                   .reject { |r| r.path.spec.to_s.start_with?("/admin/jobs") } # sidekiq

--- a/spec/lib/morph/docker_runner_spec.rb
+++ b/spec/lib/morph/docker_runner_spec.rb
@@ -28,7 +28,7 @@ describe Morph::DockerRunner do
       end
     end
 
-    it "lets me know that it can't select a buildpack" do
+    it "lets me know that it can't select a buildpack", slow: true do # 5.3 seconds
       c = described_class.compile_and_start_run(repo_path: dir) do |_timestamp, stream, text|
         docker_output << [stream, text]
       end
@@ -46,7 +46,7 @@ describe Morph::DockerRunner do
         .to eq container_count
     end
 
-    it "stops if a python compile fails" do
+    it "stops if a python compile fails", slow: true do # 5.2 seconds
       copy_test_scraper("failing_compile_python")
       c = described_class.compile_and_start_run(repo_path: dir) do |_timestamp, stream, text|
         docker_output  << [stream, text]
@@ -54,7 +54,7 @@ describe Morph::DockerRunner do
       expect(c).to be_nil
     end
 
-    it "is able to run nodejs example" do
+    it "is able to run nodejs example", slow: true do # 1.6 seconds
       copy_example_scraper("nodejs")
 
       c = described_class.compile_and_start_run(repo_path: dir, platform: platform) do |_timestamp, stream, text|
@@ -69,7 +69,7 @@ describe Morph::DockerRunner do
       expect(docker_output.last).to eq [:stdout, "1: Example Domain\n"]
     end
 
-    it "is able to run perl example" do
+    it "is able to run perl example", slow: true do # 2.4 seconds
       copy_example_scraper("perl")
 
       c = described_class.compile_and_start_run(repo_path: dir, platform: platform) do |_timestamp, stream, text|
@@ -85,7 +85,7 @@ describe Morph::DockerRunner do
       expect(docker_output.last).to eq [:stdout, "1: Example Domain\n"]
     end
 
-    it "is able to run php example" do
+    it "is able to run php example", slow: true do # > 1 second
       copy_example_scraper("php")
 
       c = described_class.compile_and_start_run(repo_path: dir, platform: platform) do |_timestamp, stream, text|
@@ -100,7 +100,7 @@ describe Morph::DockerRunner do
       expect(docker_output.last).to eq [:stdout, "1: Example Domain\n"]
     end
 
-    it "is able to run python example" do
+    it "is able to run python example", slow: true do # 7.3 seconds
       copy_example_scraper("python")
 
       c = described_class.compile_and_start_run(repo_path: dir, platform: platform) do |_timestamp, stream, text|
@@ -118,7 +118,7 @@ describe Morph::DockerRunner do
 
     # FIXME: test python when we add heroku-24 as ceder-4 and heroku-18 can't find any python versions
 
-    it "is able to run ruby example" do
+    it "is able to run ruby example", slow: true do # 3.0 seconds
       copy_example_scraper("ruby")
 
       c = described_class.compile_and_start_run(repo_path: dir, platform: platform) do |_timestamp, stream, text|
@@ -157,7 +157,7 @@ describe Morph::DockerRunner do
       result
     end
 
-    it "does not allocate and retain too much memory when running scraper" do
+    it "does not allocate and retain too much memory when running scraper", slow: true do # 1.3 seconds
       copy_test_scraper("hello_world_js")
 
       # Limit the buffer size just for testing
@@ -197,7 +197,7 @@ describe Morph::DockerRunner do
       c.delete
     end
 
-    it "is not able to run hello world from a sub-directory" do
+    it "is not able to run hello world from a sub-directory", slow: true do # 32 seconds
       copy_test_scraper("hello_world_subdirectory_js")
 
       c = described_class.compile_and_start_run(repo_path: dir, platform: platform) do |_timestamp, stream, text|
@@ -339,7 +339,7 @@ describe Morph::DockerRunner do
       ]
     end
 
-    it "streams output if the right things are set for the language" do
+    it "streams output if the right things are set for the language", slow: true do # 1.6 seconds
       copy_test_scraper("stream_output_ruby")
 
       docker_output = []
@@ -355,7 +355,7 @@ describe Morph::DockerRunner do
       expect(end_time - start_time).to be_within(0.1).of(1.0)
     end
 
-    it "is able to reconnect to a running container" do
+    it "is able to reconnect to a running container", slow: true do # 1.6 seconds
       copy_test_scraper("stream_output_ruby")
 
       logs = []
@@ -379,7 +379,7 @@ describe Morph::DockerRunner do
       expect(logs).to eq ["Started!\n", "1...\n", "2...\n", "3...\n", "4...\n", "5...\n", "6...\n", "7...\n", "8...\n", "9...\n", "10...\n", "Finished!\n"]
     end
 
-    it "is able to limit the amount of log output" do
+    it "is able to limit the amount of log output", slow: true do # 1.6 seconds
       copy_test_scraper("stream_output_ruby")
 
       c = described_class.compile_and_start_run(repo_path: dir, max_lines: 5, platform: platform)

--- a/spec/lib/morph/github_app_installation_spec.rb
+++ b/spec/lib/morph/github_app_installation_spec.rb
@@ -40,19 +40,19 @@ describe Morph::GithubAppInstallation, :github_integration do
   end
 
   describe "#confirm_has_access_to" do
-    it "returns nil when app has access to repo" do
+    it "returns nil when app has access to repo", slow: true do # 2 seconds
       error = installation.confirm_has_access_to("yarra")
       expect(error).to be_nil
     end
 
-    it "returns AppInstallationNoAccessToRepo when repo doesn't exist" do
+    it "returns AppInstallationNoAccessToRepo when repo doesn't exist", slow: true do # 2 seconds
       error = installation.confirm_has_access_to("no-such-scraper")
       expect(error).to be_a(Morph::GithubAppInstallation::AppInstallationNoAccessToRepo)
     end
   end
 
   describe "#repository_private?" do
-    it "returns false for public repo" do
+    it "returns false for public repo", slow: true do # 1.9 seconds
       result, error = installation.repository_private?("yarra")
       expect(error).to be_nil
       expect(result).to be false
@@ -60,7 +60,7 @@ describe Morph::GithubAppInstallation, :github_integration do
   end
 
   describe "#contributor_nicknames" do
-    it "returns array of contributor logins" do
+    it "returns array of contributor logins", slow: true do # 1.1 seconds
       contributors, error = installation.contributor_nicknames("yass")
       expect(error).to be_nil
       expect(contributors).to be_an(Array)
@@ -68,7 +68,7 @@ describe Morph::GithubAppInstallation, :github_integration do
       expect(contributors).not_to be_empty
     end
 
-    it "returns NoAccessToRepo error for nonexistent repo" do
+    it "returns NoAccessToRepo error for nonexistent repo", slow: true do # 1.0 seconds
       contributors, error = installation.contributor_nicknames("no-such-scraper")
       expect(contributors).to eq([])
       expect(error).to be_a(Morph::GithubAppInstallation::NoAccessToRepo)
@@ -76,7 +76,7 @@ describe Morph::GithubAppInstallation, :github_integration do
   end
 
   describe "#collaborators" do
-    it "returns array of collaborators with permissions" do
+    it "returns array of collaborators with permissions", slow: true do # 1.1 seconds
       collaborators, error = installation.collaborators("yarra")
       expect(error).to be_nil
       expect(collaborators).to be_an(Array)
@@ -84,7 +84,7 @@ describe Morph::GithubAppInstallation, :github_integration do
       expect(collaborators.first.permissions.admin).to be_in([true, false])
     end
 
-    it "returns NoAccessToRepo error for nonexistent repo" do
+    it "returns NoAccessToRepo error for nonexistent repo", slow: true do # 1.1 seconds
       collaborators, error = installation.collaborators("no-such-scraper")
       expect(collaborators).to eq([])
       expect(error).to be_a(Morph::GithubAppInstallation::NoAccessToRepo)

--- a/spec/lib/morph/runner_spec.rb
+++ b/spec/lib/morph/runner_spec.rb
@@ -40,7 +40,7 @@ describe Morph::Runner do
       expect(run.database.no_rows).to eq 1
     end
 
-    it "magicallies handle a sidekiq queue restart" do
+    it "magicallies handle a sidekiq queue restart", slow: true do # 1.9 seconds
       owner = User.create(nickname: "mlandauer")
       run = Run.create(owner: owner)
       FileUtils.rm_rf(run.data_path)
@@ -93,7 +93,7 @@ describe Morph::Runner do
       ]
     end
 
-    it "handles restarting from a stopped container" do
+    it "handles restarting from a stopped container", slow: true do # 2.9 seconds
       owner = User.create(nickname: "mlandauer")
       run = Run.create(owner: owner)
       FileUtils.rm_rf(run.data_path)
@@ -155,7 +155,7 @@ describe Morph::Runner do
       ]
     end
 
-    it "is able to limit the number of lines of output" do
+    it "is able to limit the number of lines of output", slow: true do # 1.9 seconds
       owner = User.create(nickname: "mlandauer")
       run = Run.create(owner: owner)
       FileUtils.rm_rf(run.data_path)
@@ -195,7 +195,7 @@ describe Morph::Runner do
     #   expect(subnet).to eq "192.168"
     # end
 
-    it "is able to correctly limit the number of lines even after a restart" do
+    it "is able to correctly limit the number of lines even after a restart", slow: true do # 1.9 seconds
       owner = User.create(nickname: "mlandauer")
       run = Run.create(owner: owner)
       FileUtils.rm_rf(run.data_path)
@@ -233,7 +233,7 @@ describe Morph::Runner do
 
   # TODO: Test that we can stop the compile stage
   describe ".stop!", docker: true do
-    it "is able to stop a scraper running in a continuous loop" do
+    it "is able to stop a scraper running in a continuous loop", slow: true do # 1.1 seconds
       owner = User.create(nickname: "mlandauer")
       run = Run.create(owner: owner)
       FileUtils.rm_rf(run.data_path)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,7 +111,7 @@ RSpec.configure do |config|
 
   github_integration_possible = File.exist?(Morph::GithubAppInstallation::MORPH_GITHUB_APP_PRIVATE_KEY_PATH)
 
-  config.filter_run_excluding github: true if ENV["DONT_RUN_GITHUB_TESTS"] && !github_integration_possible
+  config.filter_run_excluding github: true if ENV["DONT_RUN_GITHUB_TESTS"] || !github_integration_possible
   config.filter_run_excluding docker: true if ENV["DONT_RUN_DOCKER_TESTS"]
   config.filter_run_excluding slow: true unless ENV["RUN_SLOW_TESTS"]
 


### PR DESCRIPTION
## Relevant issue(s)

- https://github.com/openaustralia/morph/issues/1431

## What does this do?

Adjusted make test command to run quick tests first, then all tests (to get a full coverage/index.html report).

I flagged tests that take more than a second as slow.

I changed the github workflow so that all tests are run, so failing slow tests are picked up rather than being avoided because they are not run by the default rake or rspec commands (Changes runtime from 29 to 43 seconds)

On my system make quick-tests (excludes slow, docker and github tests) reports:

    Finished in 9.97 seconds (files took 2.74 seconds to load)
    451 examples, 0 failures, 1 pending
In comparison make all-tests reports:

    Finished in 2 minutes 13.4 seconds (files took 2.82 seconds to load)
    490 examples, 0 failures, 3 pending
(8.6% more spec examples for 1,238% more time)

**I Donated my time to do this**

Includes PR:
* https://github.com/openaustralia/morph/pull/1429

## Why was this needed?

Improves productivity, improves github tests

