### PR TITLE
Re-enabled php and perl languages for testing and continue to work on heroku-18 HOTFIX

### DIFF
--- a/app/lib/morph/language.rb
+++ b/app/lib/morph/language.rb
@@ -5,9 +5,8 @@ module Morph
   # Special stuff for each scripting language supported by morph.io
   class Language
     extend T::Sig
-    # FIXME: get php and perl examples / buildstep working and add it back here
-    # heroku-18 had LANGUAGES_SUPPORTED = T.let(%i[ruby php python perl nodejs].freeze, T::Array[Symbol])
-    LANGUAGES_SUPPORTED = T.let(%i[ruby python nodejs].freeze, T::Array[Symbol])
+    # FIXME: get php and perl examples / buildstep working for heroku-24
+    LANGUAGES_SUPPORTED = T.let(%i[ruby php python perl nodejs].freeze, T::Array[Symbol])
 
     WEBSITES = T.let({
       ruby: "https://www.ruby-lang.org/en/",


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/morph/issues/1440

## What does this do?

Re-enabled php and perl languages

## Why was this needed?

For testing and so heroku-18 php/perl scrapers continue to work

## Implementation/Deploy Steps (Optional)

I manually hotfixed morph.io.

standard capistrano deploy

## Notes to reviewer (Optional)

Examples will be updated on a separate PR as they are breaking on morph.io even though they work in spec