### PR TITLE
Feature: allow webhook to include run stats

### DIFF
--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -33,6 +33,7 @@
   * REMOVED: Records removed count
   * REVISION: Abbreviated git revision (e.g. "c9fab2s7")
   * RUN_TIME: Seconds taken to run (eg "603" is 10 minutes and 3 seconds)
+  * SCRAPER: Full scraper name, eg "owner-name/repo-name"
   * STATUS_CODE: Process exit code (0 means success)
 
   If there’s something specific you’d like included in the webhook payload

--- a/app/views/documentation/webhooks.html.haml
+++ b/app/views/documentation/webhooks.html.haml
@@ -24,6 +24,17 @@
   You can send information through the request
   by putting it in the webhook URL,
   either as the path or as GET parameters.
+  The following UPPERCASE strings will be replaced with the current run details in the url:
+
+  * ADDED: Records added count
+  * AUTO: "true" if an automatic daily run, otherwise "false"
+  * COMMIT: Full git revision
+  * OUTCOME: "success" if run finished successfully, otherwise "failed"
+  * REMOVED: Records removed count
+  * REVISION: Abbreviated git revision (e.g. "c9fab2s7")
+  * RUN_TIME: Seconds taken to run (eg "603" is 10 minutes and 3 seconds)
+  * STATUS_CODE: Process exit code (0 means success)
+
   If there’s something specific you’d like included in the webhook payload
   then please [ask a question on our help forum](#{host_origin("help")}/).
 

--- a/app/workers/deliver_webhook_worker.rb
+++ b/app/workers/deliver_webhook_worker.rb
@@ -13,7 +13,7 @@ class DeliverWebhookWorker
     # TODO: As soon as we've upgraded to a recent version of Ubuntu switch the SSL
     # verification back on. It's not crazy-super important that we verify SSL with
     # webhooks but it's sure a good idea.
-    connection = Faraday.new(webhook_delivery.webhook.url, ssl: { verify: false })
+    connection = Faraday.new(substituted_url(webhook_delivery), ssl: { verify: false })
     begin
       response = connection.post
       webhook_delivery.update(
@@ -25,5 +25,25 @@ class DeliverWebhookWorker
       # more important errors. Also, we don't want these just constantly retrying after failures
       Rails.logger.error("Webhook delivery failure on scraper #{webhook_delivery.run.scraper.full_name}: #{e}")
     end
+  end
+
+  private
+
+  def substituted_url(webhook_delivery)
+    url = webhook_delivery.webhook.url
+    run = webhook_delivery.run
+    {
+      "ADDED" => run.records_added,
+      "AUTO" => run.auto?,
+      "COMMIT" => run.git_revision,
+      "OUTCOME" => run.finished_successfully? ? "success" : "failed",
+      "REMOVED" => run.records_removed,
+      "REVISION" => run.git_revision[0..7],
+      "RUN_TIME" => run.wall_time.to_i,
+      "STATUS_CODE" => run.status_code
+    }.each do |name, value|
+      url = url.gsub(name, value.to_s)
+    end
+    url
   end
 end

--- a/app/workers/deliver_webhook_worker.rb
+++ b/app/workers/deliver_webhook_worker.rb
@@ -40,6 +40,7 @@ class DeliverWebhookWorker
       "REMOVED" => run.records_removed,
       "REVISION" => run.git_revision[0..7],
       "RUN_TIME" => run.wall_time.to_i,
+      "SCRAPER" => run.scraper.full_name,
       "STATUS_CODE" => run.status_code
     }.each do |name, value|
       url = url.gsub(name, value.to_s)

--- a/spec/lib/morph/language_spec.rb
+++ b/spec/lib/morph/language_spec.rb
@@ -4,6 +4,11 @@
 require "spec_helper"
 
 describe Morph::Language do
+  before do
+    # Clear any files from manual testing
+    Dir.glob("default_files/*/template/data.sqlite").each { |file| File.delete(file) }
+  end
+
   let(:ruby) { described_class.new(:ruby) }
   let(:python) { described_class.new(:python) }
   let(:php) { described_class.new(:php) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,7 +67,7 @@ require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "capybara/rspec"
 require "rspec/sorbet"
-require "webmock/rspec"
+# require "webmock/rspec"
 
 # Commented out for the benefit of zeus
 # require 'rspec/autorun'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,7 @@ require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "capybara/rspec"
 require "rspec/sorbet"
+require "webmock/rspec"
 
 # Commented out for the benefit of zeus
 # require 'rspec/autorun'

--- a/spec/workers/deliver_webhook_worker_spec.rb
+++ b/spec/workers/deliver_webhook_worker_spec.rb
@@ -69,6 +69,7 @@ describe DeliverWebhookWorker do
         "REMOVED" => run.records_removed,
         "REVISION" => "c9fabbc7",
         "RUN_TIME" => run.wall_time.to_i,
+        "SCRAPER" => run.scraper.full_name,
         "STATUS_CODE" => run.status_code
       }
 

--- a/spec/workers/deliver_webhook_worker_spec.rb
+++ b/spec/workers/deliver_webhook_worker_spec.rb
@@ -3,18 +3,98 @@
 
 require "spec_helper"
 
-describe DeliverWebhookWorker, :vcr do
+describe DeliverWebhookWorker do
   let(:scraper) { create(:scraper) }
-  let(:run) { create(:run) }
+  let(:run) do
+    create(:run,
+           git_revision: "c9fabbc7a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+           records_added: 100,
+           records_removed: 200,
+           status_code: 3,
+           started_at: 400.4.seconds.ago,
+           finished_at: 0.1.seconds.ago,
+           auto: true)
+  end
 
-  it "works" do
-    VCR.use_cassette("webhook_delivery") do
-      webhook = Webhook.create!(scraper: scraper, url: "http://requestb.in/x3pcr8x3")
+  describe "test to actual site", :vcr do
+    it "works" do
+      VCR.use_cassette("webhook_delivery") do
+        webhook = Webhook.create!(scraper: scraper, url: "http://requestb.in/x3pcr8x3")
+        webhook_delivery = webhook.deliveries.create!(run: run)
+        described_class.new.perform(webhook_delivery.id)
+        webhook_delivery.reload
+        expect(webhook_delivery.response_code).to be(200)
+        expect(webhook_delivery.sent_at).to be_within(1.minute).of(DateTime.now)
+      end
+    end
+  end
+
+  describe "error handling" do
+    it "records response code and time on success" do
+      webhook = Webhook.create!(scraper: scraper, url: "http://example.com/hook")
       webhook_delivery = webhook.deliveries.create!(run: run)
+
+      stub_request(:post, "http://example.com/hook").to_return(status: 200)
+
       described_class.new.perform(webhook_delivery.id)
+
       webhook_delivery.reload
-      expect(webhook_delivery.response_code).to be(200)
+      expect(webhook_delivery.response_code).to eq(200)
       expect(webhook_delivery.sent_at).to be_within(1.minute).of(DateTime.now)
+    end
+
+    it "logs connection failures without raising" do
+      webhook = Webhook.create!(scraper: scraper, url: "http://example.com/hook")
+      webhook_delivery = webhook.deliveries.create!(run: run)
+
+      stub_request(:post, "http://example.com/hook").to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+
+      allow(Rails.logger).to receive(:error)
+
+      expect do
+        described_class.new.perform(webhook_delivery.id)
+      end.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(/Webhook delivery failure/)
+    end
+  end
+
+  describe "URL substitution" do
+    it "substitutes all placeholders correctly" do
+      substitutions = {
+        "ADDED" => run.records_added,
+        "AUTO" => run.auto,
+        "COMMIT" => run.git_revision,
+        "OUTCOME" => "failed",
+        "REMOVED" => run.records_removed,
+        "REVISION" => "c9fabbc7",
+        "RUN_TIME" => run.wall_time.to_i,
+        "STATUS_CODE" => run.status_code
+      }
+
+      url_template = "https://example.com/?#{substitutions.keys.map { |k| "#{k.downcase}=#{k}" }.join('&')}"
+      expected_url = "https://example.com/?#{substitutions.map { |k, v| "#{k.downcase}=#{v}" }.join('&')}"
+
+      webhook = Webhook.create!(scraper: scraper, url: url_template)
+      webhook_delivery = webhook.deliveries.create!(run: run)
+
+      stub = stub_request(:post, expected_url).to_return(status: 200)
+
+      described_class.new.perform(webhook_delivery.id)
+
+      expect(stub).to have_been_requested.once
+    end
+
+    it "uses 'success' for OUTCOME when run succeeds" do
+      run.update!(status_code: 0)
+      webhook = Webhook.create!(scraper: scraper, url: "https://example.com/?outcome=OUTCOME")
+      webhook_delivery = webhook.deliveries.create!(run: run)
+
+      stub = stub_request(:post, "https://example.com/?outcome=success").to_return(status: 200)
+
+      described_class.new.perform(webhook_delivery.id)
+
+      expect(stub).to have_been_requested.once
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

These are the issues that triggered the need for this change.

* https://github.com/openaustralia/morph/issues/1439
* https://github.com/openaustralia/morph/issues/1342

## What does this do?

As documented in app/views/documentation/webhooks.html.haml: The following UPPERCASE strings will be replaced with the current run details in the url:

  * ADDED: Records added count
  * AUTO: "true" if an automatic daily run, otherwise "false"
  * COMMIT: Full git revision
  * OUTCOME: "success" if run finished successfully, otherwise "failed"
  * REMOVED: Records removed count
  * REVISION: Abbreviated git revision (e.g. "c9fab2s7")
  * RUN_TIME: Seconds taken to run (eg "603" is 10 minutes and 3 seconds)
  * SCRAPER: Full scraper name, eg "owner-name/repo-name"
  * STATUS_CODE: Process exit code (0 means success)

Specs have been added to check the new functionality, as well as test if the webhook fails (previously uncovered check).

## Why was this needed?

My [plannies mate](https://plannies-mate.thesite.info/) site was unable to access run details for private repos since I made all of my multiple*-prs repos private. (which I did after I was given access to the "private" flag for morph).

**The time to do this was a donation to OAF**

## Implementation/Deploy Steps (Optional)

Standard capistrano deploy.

## Notes to reviewer (Optional)

This shouldn't be a security issue in my opinion, since:

* For public scrapers, you don't need to login to see this data
* For private scrapers (our multiple_* scrapers), the same person who has access to [settings](https://morph.io/ianheggie-oaf/multiple_atdis-prs/settings) to set the webhook url, also has access to the [scraper page](https://morph.io/ianheggie-oaf/multiple_atdis-prs), which gives a red/green outcome line and lists the run history.
* No personally identifying information is included
* The values are safe for use, being constrained to either numbers, specific values, or in the case of scraper name, constrained to be url friendly by github and used by us as part of our url
  * Note: "/" has been valid in the query for the last 20 years [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4)