### PR TITLE
Fix ansible tag names, replacing hyphen with underscore to make them valid

### DIFF
--- a/provisioning/roles/discourse/meta/main.yml
+++ b/provisioning/roles/discourse/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: docker-server-linode, tags: "docker-server-linode" }
+  - { role: docker-server-linode, tags: "docker_server_linode" }

--- a/provisioning/roles/morph-app/meta/main.yml
+++ b/provisioning/roles/morph-app/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
-  - { role: docker-server-linode, tags: "docker-server-linode" }
-  - { role: nginx-passenger, tags: "nginx-passenger" }
+  - { role: docker-server-linode, tags: "docker_server_linode" }
+  - { role: nginx-passenger, tags: "nginx_passenger" }
   - { role: ruby, tags: "ruby" }
   - { role: mysql, tags: "mysql" }
   - { role: backups, tags: "backups" }

--- a/provisioning/roles/ruby/meta/main.yml
+++ b/provisioning/roles/ruby/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
   - role: deploy-user
-    tags: "deploy-user"
+    tags: "deploy_user"


### PR DESCRIPTION
## Relevant issue(s)

slack comment from ben: I still don't have access to Morph for some reason :( Thus discovering my previous ansible run was ineffective.

## What does this do?

Fixes ansible tag names that use invalid characters, eg hyphen (-) - replaced with underscore (_)

## Why was this needed?

* I ran an update to push ssh keys and it didn't add ben.
* Tags are useful to restrict provisioning updates to just what is needed

## Implementation/Deploy Steps (Optional)

Done:
```bash
TAGS=deploy_user make production-provision
```

## Notes to reviewer (Optional)

No action required apart from merge.

Originally I thought it was because the tag was in meta data, but it was because of naming restrictions - live and learn.