### PR TITLE
Fix/1477 contact us on the home page is not accurate any more

### DIFF
--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -6,7 +6,7 @@
         %ul.list-unstyled
           %li
             %i.fa.fa-envelope
-            = mail_to "contact@oaf.org.au"
+            = mail_to "support@morph.io."
           %li
             %i.fa.fa-github-alt
             = link_to "GitHub", "https://github.com/openaustralia/morph"

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -5,9 +5,6 @@
         %h4 contact us
         %ul.list-unstyled
           %li
-            %i.fa.fa-twitter
-            = link_to "@morph_io", "https://twitter.com/morph_io"
-          %li
             %i.fa.fa-envelope
             = mail_to "contact@oaf.org.au"
           %li

--- a/spec/integration/hardcoded_domain_spec.rb
+++ b/spec/integration/hardcoded_domain_spec.rb
@@ -144,7 +144,7 @@ describe "Hardcoded domain references", type: :request do
 
       # Find context around each occurrence
       matches = []
-      html.scan(/(.{0,80}(morph\.io|hostname).{0,80})/m) do |match|
+      html.scan(/(.{0,80}(?<!support@)(morph\.io|hostname).{0,80})/m) do |match|
         matches << match[0].gsub(/\s+/, " ").strip
       end
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/morph/issues/1477

## What does this do?

Fixes it

## Why was this needed?

Ben asked for the change

## Implementation/Deploy Steps (Optional)

- [ ] cap production deploy

## Notes to reviewer (Optional)

I want this other PR merged first to tag when I deploy:
* https://github.com/openaustralia/morph/pull/1479
