### PR TITLE
Update "Make a one time contribution" link to use donate site

### DIFF
--- a/app/views/supporters/new.html.haml
+++ b/app/views/supporters/new.html.haml
@@ -25,7 +25,7 @@
 
       - Plan.all_stripe_plan_ids.each do |plan_id|
         = render partial: "plan", locals: { plan: Plan.new(plan_id) }
-          
+
   .row.one-time-contribution
     %p
       Monthly contribution not right for you?

--- a/app/views/supporters/new.html.haml
+++ b/app/views/supporters/new.html.haml
@@ -25,23 +25,11 @@
 
       - Plan.all_stripe_plan_ids.each do |plan_id|
         = render partial: "plan", locals: { plan: Plan.new(plan_id) }
-
-  - if user_signed_in?
-    .row.one-time-contribution
-      %p
-        Monthly contribution not right for you?
-        = link_to "Make a one time contribution", "#supporter-one-time-form",
-          data: { toggle: "collapse" }
-      = form_tag create_one_time_supporters_path, id: "supporter-one-time-form", class: "form-inline collapse" do
-        = hidden_field_tag "stripeTokenOneTime"
-        .form-group
-          = label_tag "amount", "Amount (in US dollars)", class: "sr-only"
-          .input-group
-            .input-group-addon $
-            = number_field_tag "amount", 20, placeholder: "Amount", class: "form-control"
-        = button_tag "Contribute", class: "btn btn-success",
-          data: { key: Rails.configuration.stripe[:publishable_key],
-                  email: current_user.email }
+          
+  .row.one-time-contribution
+    %p
+      Monthly contribution not right for you?
+      = link_to "Make a one time contribution", "https://donate.oaf.org.au/?frequency=once"
 
 .plan-questions
   .container


### PR DESCRIPTION
## Description

Fixed the once off link for:
* https://github.com/openaustralia/morph/issues/1483

Changed the view so the link always appears rather than requiring user to sign in.

## Motivation and Context
I missed the last link to stripe, fixes final bit of:
* https://github.com/openaustralia/morph/issues/1483

## How Has This Been Tested?

* Tested locally with `be rails s` 
* Ran `be rake`
* Created draft PR, waited for Github checks
  * fixed whitespace complaint  
* Waited for github to finish its checks then marked PR as ready for review 

On Ubuntu 24.04.4 LTS x86_64 with mise

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
