### PR TITLE
Doc/manual security check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,10 +141,12 @@ group :development do
   gem "spring", "~> 4.0"
   gem "spring-commands-rspec"
 
+  gem "bundle-audit", require: false
   gem "rubocop"
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
   gem "rubocop-sorbet", require: false
+  gem "ruby_audit", require: false
 
   gem "mailcatcher", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,11 @@ GEM
       sassc (>= 2.0.0)
     bootstrap-select-rails (1.13.8)
     builder (3.3.0)
+    bundle-audit (0.2.0)
+      bundler-audit
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     cancancan (3.4.0)
     capistrano (3.17.0)
       airbrussh (>= 1.0.0)
@@ -561,6 +566,8 @@ GEM
       rubocop (>= 0.90.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    ruby_audit (2.3.1)
+      bundler-audit (~> 0.9.0)
     ruby_parser (3.19.1)
       sexp_processor (~> 4.16)
     rugged (1.5.0.1)
@@ -723,6 +730,7 @@ DEPENDENCIES
   bootsnap (~> 1.4)
   bootstrap-sass
   bootstrap-select-rails
+  bundle-audit
   cancancan
   capistrano-rails
   capistrano-rvm
@@ -792,6 +800,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-sorbet
   ruby-progressbar
+  ruby_audit
   rugged
   sass-rails
   sdoc

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Read the [provisioning README](provisioning/README.md) for further details.
     - See `spec/models/scraper_spec.rb` as an example split file
     - Consider splitting off concerns and domain logic into separate files when other files get too fat
 
+## To run style and coding checks
+
+    bundle exec rubocop
+
+## To check for security updates
+
+Either check [Dependabot alerts](https://github.com/openaustralia/morph/security/dependabot)
+for the main branch, taking note of when the last check was run, **or** run manually on current branch:
+
+    bundle exec ruby-audit
+    bundle exec bundle-audit
+
 ### Support for Developers / CI
 
 Docker compose is used to provide redis, elasticsearch and mysql services as required for dev and CI


### PR DESCRIPTION
## Description

Document manual security check

## Motivation and Context
Dependabot doesn't check ruby versions and it differs from how bundle checks related gems

This is in preparation of performing security updates much faster than individual merge of dependabot PRs when there are a number of them.

## How Has This Been Tested?
Ran the commands as documented (only applicable to local dev system)
on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0

Marked ready for review since github checks passed.

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
