### PR TITLE
Fix Brakeman workflow and update CI actions

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -3,31 +3,33 @@
 
 name: Brakeman Scan
 
-# This section configures the trigger for the workflow. Feel free to customize depending on your convention
 on:
+  push:
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   brakeman-scan:
     name: Brakeman Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    # Customize the ruby version depending on your needs
+    # Brakeman statically analyses the code with its own parser, so it
+    # doesn't need to run under the same Ruby version as the application
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1.1.3
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.3'
 
     - name: Setup Brakeman
-      env:
-        BRAKEMAN_VERSION: '4.10' # SARIF support is provided in Brakeman version 4.10+
-      run: |
-        gem install brakeman --version $BRAKEMAN_VERSION
+      run: gem install brakeman
 
     # Execute Brakeman CLI and generate a SARIF output with the security issues identified during the analysis
     - name: Scan
@@ -37,6 +39,6 @@ jobs:
 
     # Upload the SARIF file generated in the previous step
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: output.sarif.json

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -51,7 +51,7 @@ jobs:
     #     options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: configure rails database
         run: cp config/database-ci.yml config/database.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Install Ruby (version given by .ruby-version) and Bundler
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Description

Fixes the Brakeman workflow and brings the CI actions up to date:

- Trigger on pushes and PRs to main
- Use `ruby/setup-ruby` with Ruby 3.3 (Brakeman uses its own parser so it doesn't need the app's Ruby version)
- Install current Brakeman instead of pinning 4.10
- Add the `security-events` permission needed for SARIF upload
- Bump `actions/checkout` to v4 across workflows

## Motivation and Context

The Brakeman workflow targeted the master branch, which no longer exists (mainline is main), so it never ran. It also used the archived `actions/setup-ruby` action, a Brakeman version from 2020 and the deprecated v2 of `codeql-action`.

First step of the dependency upgrade project.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

All GitHub Actions checks are passing on this PR. Because the workflow now triggers on PRs to main, the Brakeman workflow runs on this PR itself.

## Screenshots (if appropriate):

Not applicable, no user-facing change.

## Types of Changes

None of the below apply. This is a CI/workflow chore with no change to application code or behaviour.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code/anthropic.claude-fable-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
