### PR TITLE
Raise on Rails deprecation warnings in tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,8 +39,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  # Raise on deprecation notices so new deprecations fail CI. This keeps
+  # each step of the staged Rails upgrade honest: a Rails version bump can
+  # only merge once the deprecations it introduces are fixed.
+  config.active_support.deprecation = :raise
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
## Description

Changes `config.active_support.deprecation` in the test environment from `:stderr` to `:raise`, so any Rails deprecation warning triggered during the test suite now fails the run instead of scrolling past in stderr.

Part of the staged Rails upgrade stack (stacked on #1497, `upgrade/00-config-cleanup`).

## Motivation and Context

This is the baseline guard for the staged Rails upgrade: each Rails version bump in the stack can only merge once the deprecations it introduces are fixed, because CI will raise on them. Without this, deprecation warnings accumulate silently and the upgrade debt compounds.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The full rspec suite passes with `:raise` enabled, confirming no existing deprecations fire under the current Rails version.

## Screenshots (if appropriate):

Not applicable — test configuration change only.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

None of the above: test/CI configuration change with no runtime behaviour impact.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code/anthropic.claude-fable-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
