### PR TITLE
Back up Discourse daily to S3

### DIFF
--- a/provisioning/roles/discourse/templates/app.yml.j2
+++ b/provisioning/roles/discourse/templates/app.yml.j2
@@ -64,6 +64,17 @@ env:
   DISCOURSE_SMTP_PASSWORD: '{{ cuttlefish_password }}'
 {% endif %}
   DISCOURSE_SMTP_ENABLE_START_TLS: true
+{% if backups | default(false) %}
+
+  ## Automatic daily backups to S3 (same credentials as the duply backups)
+  DISCOURSE_BACKUP_LOCATION: s3
+  DISCOURSE_S3_BACKUP_BUCKET: oaf-backups/morph/discourse
+  DISCOURSE_S3_REGION: us-east-1
+  DISCOURSE_S3_ACCESS_KEY_ID: '{{ backup_target_user }}'
+  DISCOURSE_S3_SECRET_ACCESS_KEY: '{{ backup_target_pass }}'
+  DISCOURSE_BACKUP_FREQUENCY: 1
+  DISCOURSE_MAXIMUM_BACKUPS: 14
+{% endif %}
 
   ## The CDN address for this Discourse instance (configured to pull)
   #DISCOURSE_CDN_URL: //discourse-cdn.example.com


### PR DESCRIPTION
The Discourse forum on the production server had no backups at all -
its Postgres data and uploads lived only in /var/discourse/shared on
the VM. Enable Discourse's built-in automatic backups, pushed to the
same oaf-backups S3 bucket the duply backups use, daily, keeping 14.

Only enabled where backups is true (production), so dev/staging VMs
don't write to the production bucket.

Ops note: after merging, this needs a provisioning run plus
'./launcher rebuild app' in /var/discourse on the server (or set the
equivalent site settings via the admin UI ahead of the rebuild).
Verify the first backup lands in
s3://oaf-backups/morph/discourse before trusting it.

Assisted-by: Claude Code:anthropic.claude-fable-5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>