### PR TITLE
Fix drift and duplication in support files

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,16 +39,6 @@ jobs:
       DB_DATABASE: scraping_test
       DB_USER: scraping
       DB_PASSWORD: password
-    # services:
-    #   mysql:
-    #     image: mysql:8.0
-    #     env:
-    #       MYSQL_DATABASE: scraping_test
-    #       MYSQL_USER: scraping
-    #       MYSQL_ROOT_PASSWORD: password
-    #     ports:
-    #     - 33306:3306
-    #     options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
@@ -74,8 +64,6 @@ jobs:
 
       - name: Start elasticsearch and redis Services
         run: make ci-services-up
-        # with:
-        #   stack-version: 7.5.1
 
       - name: Install Ruby (version given by .ruby-version) and Bundler
         uses: ruby/setup-ruby@v1

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all clean deploy help lint \
-        production-deploy production-provision provision \
+.PHONY: all clean help lint \
+        production-deploy production-provision \
         roles services-down services-up \
-	staging-anible staging-deploy staging-provision \
-        share-web test up vagrant-plugins venv \
+	staging-deploy staging-provision \
+        share-web test vagrant-plugins venv \
 	all-tests quick-tests
 VENV := .venv/bin
 SHELL := /bin/bash

--- a/docker-compose.override.yml-example
+++ b/docker-compose.override.yml-example
@@ -1,4 +1,4 @@
-# NOTE - copy  to docker-compose.override.yml if you want
+# NOTE - copy docker-compose.override.yml-example to docker-compose.override.yml if you want
 # fixed rather than random ports on the host for services below
 # or to override other configuration
 

--- a/env-example
+++ b/env-example
@@ -29,8 +29,10 @@ GITHUB_APP_INSTALLED_BY=xxxxxxxxxx
 # -------------------------------------------------------------------
 # Provisioning staging only
 
+# Used by capistrano for deployment and ansible playbook in provisioning
+# Required if you are deploying to staging
 # Ansible sets SERVER_NAME in deployed .env file from this value
-#STAGING_HOSTNAME=morph.your.domain
+#STAGING_HOSTNAME=morph-staging.your.domain
 
 # Required if STAGING_HOSTNAME points to a CDN: set to the actual ip address of the server
 #STAGING_DEPLOY_TO=server-ip-address
@@ -46,22 +48,15 @@ DISCOURSE_URL=http://discuss.dev.morph.io
 MITMPROXY_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxx
 MORPH_URL=http://localhost:3000
 
-# Used by capistrano for deployment and ansible playbook in provisioning
-# Required if you are deploying to staging
-#STAGING_HOSTNAME=morph-staging.your.domain
-
-# Required if STAGING_HOSTNAME points to a CDN: set to the actual ip address of the server
-#STAGING_DEPLOY_TO=server-ip-address
-
-# Ansible will set SERVER_NAME in the .env file for you
+# See https://hub.docker.com/_/mysql
+MYSQL_ROOT_PASSWORD=password
 
 # In development you can run elasticsearch on docker very easily which means
 # you don't have to install it. Use
 # SERVICES=elasticsearch make services-up
-# Then, point it at the right place. You can get the ip address of docker
-# by running: docker-machine ip
-# If you're on Linux you probably dont need the line below 
-# ELASTICSEARCH_URL=http://192.168.99.100:9200
+# If elasticsearch isn't reachable on the default url, point ELASTICSEARCH_URL
+# at the right place
+#ELASTICSEARCH_URL=http://localhost:9200
 
 # This secret key is used for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
@@ -79,26 +74,10 @@ SYNC_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 DOCKER_GID=999
 
 # -------------------------------
-# Code Development Only
-
-# See https://hub.docker.com/_/mysql
-MYSQL_ROOT_PASSWORD=password
-
-# In development you can run elasticsearch on docker very easily which means
-# you don't have to install it.
-# Just use: docker-compose up
-# Then, point it at the right place. You can get the ip address of docker
-# by running: docker-machine ip
-# If you're on Linux you can probably comment the line below out
-ELASTICSEARCH_URL=http://192.168.99.100:9200
-
-# -------------------------------
 # Optional
 
-# If this is Linux then your docker daemon is likely running locally on a socket. In that case the DOCKER_URL
-# and DOCKER_TCP does not need to be set (comment the lines below out).
-# If this is OS X, then your docker daemon will be running inside a VM with a tunneled port (see instructions
-# in the README for how to set this up)
+# If your docker daemon is running locally on a socket (the usual case) then
+# DOCKER_URL and DOCKER_TCP do not need to be set (leave the lines below commented out).
 #DOCKER_URL=http://localhost:4243
 #DOCKER_TCP=localhost:4243
 

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -86,31 +86,6 @@ Run `make roles` to install some required ansible roles.
 
 Run `vagrant up local`. This will build and provision a box that looks and acts like production at `dev.morph.io`.
 
-## Production devops development
-
-> This method defaults to creating a 4Gb VirtualBox VM, which can strain an 8Gb Mac.
-> We suggest tweaking the Vagrantfile to restrict ram usage to 2Gb at first, or using a machine with at least 12Gb ram.
-
-Install [Vagrant](http://www.vagrantup.com/), [VirtualBox](https://www.virtualbox.org) and [Ansible](http://www.ansible.com/).
-
-Install a couple of Vagrant plugins: `vagrant plugin install vagrant-hostsupdater vagrant-disksize`
-
-Install a Ruby Version Manager, for example (from latest to oldest):
-- [mise](https://mise.jdx.dev/) - modern, polyglot and fast (includes language installer)
-- [chruby](https://github.com/postmodern/chruby) and [ruby-install](https://github.com/postmodern/ruby-install) - a lightweight alternative
-- [rbenv](https://github.com/rbenv/rbenv) and [ruby-build](https://github.com/rbenv/ruby-build#readme) - the leader between 2015 and 2020
-- [rvm](https://rvm.io/) - used on production and staging, the old faithful and well known ruby version manager
-
-If on Ubuntu, install libreadline-dev: `sudo apt install libreadline-dev libsqlite3-dev`
-
-Install the required ruby version: `rbenv install`
-
-Install capistrano: `gem install capistrano`
-
-Run `make roles` to install some required ansible roles.
-
-Run `vagrant up local`. This will build and provision a box that looks and acts like production at `dev.morph.io`.
-
 Once the box is created and provisioned, deploy the application to your Vagrant box:
 
     cap local deploy
@@ -121,7 +96,7 @@ Now visit https://dev.morph.io/
 
 When you've changed the Ansible playbooks to modify the infrastructure you'll want to run:
 
-    make ansible
+    make production-provision
 
 ## SSL certificates
 


### PR DESCRIPTION
Part of #1506.

## What

- **`provisioning/README.md`** - the entire "Production devops development" section was duplicated verbatim back-to-back (copy-paste/merge artifact). Merged into one copy that keeps the superset of both: the `vagrant-vbguest` plugin (first copy only) and the `cap local deploy` tail (second copy only). Also fixes `make ansible` → `make production-provision` (the `ansible` target doesn't exist).
- **`env-example`** - three blocks each appeared twice: the `STAGING_HOSTNAME`/`STAGING_DEPLOY_TO` settings, the "Code Development Only" header, and the elasticsearch guidance. Merged each. Also removed guidance referencing the long-dead `docker-machine` and old `docker-compose up` syntax, commented out `ELASTICSEARCH_URL` (`make services-up` exposes elasticsearch on `localhost:9200`, which is also the searchkick default - the previous uncommented `192.168.99.100` was a docker-machine IP that broke anyone copying the file verbatim), and dropped the pointer to OS X docker setup instructions that no longer exist in the README.
- **`docker-compose.override.yml-example`** - the first line said "copy  to docker-compose.override.yml" with the source filename missing (botched edit).
- **`Makefile`** - `.PHONY` listed four names that are not targets: `deploy`, `provision`, `up`, and the misspelt `staging-anible`.
- **`.github/workflows/ruby.yml`** - removed the commented-out mysql `services:` block and the `stack-version` remnant.

## How verified

- `make help` renders the full target list correctly after the `.PHONY` change
- Workflow YAML parses (`YAML.load_file`)
- Confirmed `docker_images/services.yaml` maps elasticsearch to host port 9200 before changing the `ELASTICSEARCH_URL` example
- Diffed the two duplicated provisioning sections to confirm the merged copy loses nothing

## AI assistance

Prepared with AI assistance (OpenCode with anthropic.claude-fable-5); reviewed by a human before submission.