### PR TITLE
Add agent-facing domain docs and align AGENTS.md with the org standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,15 @@ The pieces that make this more than a CRUD app all live in `app/lib/morph/`:
 Background work runs through Sidekiq (`app/workers/`, queues `default` and
 `scraper` per `config/sidekiq.yml`). Search is Elasticsearch via searchkick.
 Live log streaming is faye plus render_sync (`sync.ru`, the `faye` process in
-`Procfile`). Outbound scraper traffic is logged by a mitmproxy container
-(`docker_images/morph-mitmdump/`) which calls back into the API. The admin
-interface is ActiveAdmin under `/admin`.
+`Procfile`). The admin interface is ActiveAdmin under `/admin`.
+
+Outbound scraper traffic was logged by a mitmproxy container
+(`docker_images/morph-mitmdump/`) calling back into the API, but that path is
+switched off: `Morph::Runner` passes `disable_proxy: true` unconditionally, so a
+run never joins the proxy network. The container, the `connection_logs`
+endpoint, and the code that displays and searches scraped domains all remain, on
+historical data only. Issue #1506 records this half-live state as needing a
+product decision, so leave both halves alone rather than tidying either away.
 
 Scraper git repos and their SQLite databases live under `db/scrapers/`, which
 is gitignored and is a Capistrano `linked_dir` in production. It is live data,
@@ -214,11 +220,6 @@ In short: branch off `main` using the
 assign it to yourself, take it out of draft only once the checks in
 `.github/workflows/` pass, and sign off every commit with `git commit -s`.
 
-**`README.md` contradicts the org guide in two places, and the org guide wins.**
-Its "How to contribute" section describes a fork-and-pull-request flow rather
-than branching off `main`, and its "Branch naming" section uses `docs/` where
-the org guide uses `doc/`. Neither README section mentions the DCO sign-off.
-
 `.github/CODEOWNERS` in this repository requests reviews. Note that a review is
 about understanding the change together, not gatekeeping it.
 
@@ -265,8 +266,6 @@ are no ADRs yet. See `docs/agents/domain.md`.
 
 ## Known rough edges
 
-- `README.md` links to `doc/docker_development_commands.md`, which does not
-  exist in this repository.
 - `config/routes.rb` wraps `devise_for` in a `Owner.table_exists?` check so
   that migrations can run against a database without the table. Adding routes
   near that block needs care.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,38 @@ and others) when working with code in this repository. `CLAUDE.md` and
 `.github/copilot-instructions.md` point here so the guidance lives in one
 place.
 
+## Org-wide standards
+
+OAF keeps its shared standards in the `openaustralia/.github` repository. They
+are referenced here rather than restated, because copies drift. Read them before
+you start. Where this file disagrees with them, they win and this file is what
+needs fixing.
+
+- [`AGENTS.md`](https://github.com/openaustralia/.github/blob/main/AGENTS.md).
+  Its "Working as an agent in any OAF repository" section covers scoping
+  standing approvals and Bash allow-patterns, staging commits instead of making
+  them, opening pull requests as drafts assigned to the human driving the
+  change, leaving issue creation to a human unless asked, and handling secrets
+  and personal details. Its conventions section covers how OAF writes:
+  non-partisan, Australian English, no em dashes, AI disclosure, citing sources
+  and licences, replacement code in review comments, and not hard-wrapping pull
+  request or issue bodies.
+- [`.github/CONTRIBUTING.md`](https://github.com/openaustralia/.github/blob/main/.github/CONTRIBUTING.md).
+  The authority on GitHub Flow, branch naming, pull requests, the DCO sign-off
+  and AI disclosure. This repository has no local `CONTRIBUTING.md`, so that one
+  applies in full.
+- The issue and pull request templates there are inherited by this repository,
+  so they are not found locally and `gh issue create` will not offer one to
+  fill in.
+
+Fetch the current version of any of them whichever way your tools allow, for
+example:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/openaustralia/.github/main/AGENTS.md
+gh api repos/openaustralia/.github/contents/AGENTS.md --jq .content | base64 -d
+```
+
 ## What this repository is
 
 `openaustralia/morph` is the Rails application behind [morph.io](https://morph.io),
@@ -208,31 +240,16 @@ services-down` unless you actually mean to lose the databases.
 
 ## Contributing
 
-This repository has no `CONTRIBUTING.md`, so the org-wide one applies:
-[`openaustralia/.github/.github/CONTRIBUTING.md`](https://github.com/openaustralia/.github/blob/main/.github/CONTRIBUTING.md).
-It is the authority on branching, pull requests, sign-off and AI disclosure.
-The pull request and issue templates are inherited from that repository too,
-so they will not be found locally.
+Branching, pull requests, the DCO sign-off, AI disclosure and OAF's writing
+conventions all come from the org-wide standards linked at the top of this file.
+Read those rather than looking for a local copy of them here.
 
-In short: branch off `main` using the
-[Conventional Branch](https://conventionalbranch.org/#summary) form
-`type/issue-number-short-description`, open the pull request as a draft early,
-assign it to yourself, take it out of draft only once the checks in
-`.github/workflows/` pass, and sign off every commit with `git commit -s`.
+Specific to this repository:
 
-`.github/CODEOWNERS` in this repository requests reviews. Note that a review is
-about understanding the change together, not gatekeeping it.
-
-## Conventions specific to this org
-
-- Non-partisan: nothing in this repository should imply endorsement or
-  criticism of any party, candidate or position.
-- Australian English throughout.
-- No em dashes. Use a hyphen, a comma or a full stop.
-- Disclose AI involvement in both places the org `CONTRIBUTING.md` asks for: an
-  `Assisted-by: <agent-name>:<model-id>` trailer on each commit, and a note in
-  the pull request description. Report the model actually used, not a
-  remembered default. A human, not an agent, signs off the commit.
+- `.github/CODEOWNERS` requests reviews. A review is about understanding the
+  change together, not gatekeeping it.
+- Checks live in `.github/workflows/`, so those are the ones that have to pass
+  before a pull request comes out of draft.
 - `README.md` sets coding standards worth honouring beyond RuboCop: keep
   methods short, keep files under about 400 lines, and comment why rather than
   what. `spec/models/scraper_spec.rb` is the worked example of splitting a file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,30 @@ about understanding the change together, not gatekeeping it.
 - Code that cannot be covered automatically is marked `# :nocov:` and listed in
   `TESTING.md` as a manual test. If you add such code, add it there too.
 
+## Agent skills
+
+Per-repo configuration for the `mattpocock-skills` engineering skills,
+scaffolded by `/setup-matt-pocock-skills`. The details live in `docs/agents/`
+and this section is a summary. Edit those files directly rather than re-running
+the setup skill.
+
+### Issue tracker
+
+GitHub issues on `openaustralia/morph`, via the `gh` CLI. See
+`docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage labels, unchanged: `needs-triage`, `needs-info`,
+`ready-for-agent`, `ready-for-human` and `wontfix`. All already exist on the
+repo. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. [`CONTEXT.md`](CONTEXT.md) at the repo root is the glossary of
+morph.io's domain terms, and is opinionated about which words to avoid. There
+are no ADRs yet. See `docs/agents/domain.md`.
+
 ## Known rough edges
 
 - `README.md` links to `doc/docker_development_commands.md`, which does not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,16 @@ The pieces that make this more than a CRUD app all live in `app/lib/morph/`:
 - `Morph::Language` maps a scraper repo to a supported language (Ruby, Python,
   PHP, Perl, JavaScript) and to the right default files.
 
+One more piece sits outside that directory. `SynchroniseRepoService`
+(`app/services/`) is what `Morph::Runner` calls to fetch the latest scraper
+code, and is where the GitHub App failures that reach the user as a failed run
+come from.
+
 Background work runs through Sidekiq (`app/workers/`, queues `default` and
-`scraper` per `config/sidekiq.yml`). Search is Elasticsearch via searchkick.
+`scraper` per `config/sidekiq.yml`), plus scheduled rake tasks in
+`lib/tasks/app.rake` whose descriptions say they are called from cron:
+`auto_run_scrapers`, `send_alerts`, `stop_long_running_scrapers` and the refresh
+tasks. Search is Elasticsearch via searchkick.
 Live log streaming is faye plus render_sync (`sync.ru`, the `faye` process in
 `Procfile`). The admin interface is ActiveAdmin under `/admin`.
 
@@ -103,6 +111,25 @@ make services-down
 make services-status
 ```
 
+Then install the gems, create the schema, and start the app:
+
+```sh
+bundle install
+bundle exec dotenv rake db:setup
+bundle exec dotenv foreman start        # http://127.0.0.1:3000
+bundle exec rake app:promote_to_admin   # gives your account access to /admin
+```
+
+The `dotenv` prefix is load bearing, because without it the process does not see
+`.env`. `foreman` starts the `web`, `worker` and `faye` processes in `Procfile`
+together, where `rails s` on its own gives you the web process without Sidekiq
+or live log streaming.
+
+Those commands, and every other command in this file, run on the host. The
+alternative is the full Docker environment including the Ruby containers, which
+is `make docker-up`, marked BETA in the `Makefile`. With that running, get a
+shell in the web container with `docker compose exec web bash -i`.
+
 `README.md` has the full walkthrough for creating the GitHub App and filling in
 the `GITHUB_APP_*` values in `.env`. The private key it tells you to save to
 `config/morph-github-app.private-key.pem` is what gates the GitHub-integration
@@ -120,6 +147,9 @@ make all-tests     # everything, including the slow Docker integration specs.
 make test          # quick-tests then all-tests
 ```
 
+`make help` lists all 24 targets. This file covers only the ones whose behaviour
+is not obvious from the name.
+
 Three environment variables control what gets skipped, and `spec/spec_helper.rb`
 sets them itself when the prerequisites are missing:
 
@@ -130,6 +160,10 @@ sets them itself when the prerequisites are missing:
 - `DONT_RUN_GITHUB_TESTS=1` excludes specs tagged `:github`. These are also
   excluded automatically if `GITHUB_APP_INSTALLED_BY` is unset or
   `config/morph-github-app.private-key.pem` is missing.
+
+`make rspec` is a fourth entry point, running `RAILS_ENV=test bundle exec rspec`
+and setting none of those variables itself, so slow specs stay excluded unless
+you pass `RUN_SLOW_TESTS=1` yourself.
 
 CI (`.github/workflows/ruby.yml`) runs `bundle exec rspec spec -fd` with all
 three of `DONT_RUN_DOCKER_TESTS=1 RUN_SLOW_TESTS=1 DONT_RUN_GITHUB_TESTS=1`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,12 +125,12 @@ _Avoid_: notification, digest, warning
 ### Traffic
 
 **Domain**:
-A site a Scraper made requests to, recorded so people can see what a Scraper
-scrapes and find scrapers by the sites they cover. Never morph.io's own domain,
-and unrelated to "domain" in the domain-modelling sense.
+A site a Scraper made requests to. Shown on the Scraper's page and indexed for
+search, so people can find scrapers by the sites they cover. Never morph.io's
+own domain, and unrelated to "domain" in the domain-modelling sense.
 _Avoid_: site, host, target
 
 **Connection log**:
-A record that a Run made a request to a Domain, captured from the proxy the
-Run's traffic passes through.
+A record that a Run made a request to a Domain. Historical only, since the proxy
+that captured these is switched off.
 _Avoid_: request log, access log

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,136 @@
+# morph.io
+
+morph.io runs scrapers for people. A scraper is a program in someone's GitHub
+repository. morph.io builds it into a container, runs it on a schedule or on
+demand, and serves whatever it writes back out through a web UI and an API.
+
+This file is a glossary and nothing else. Standing guidance for working in the
+repository is in [`AGENTS.md`](./AGENTS.md).
+
+## Language
+
+### People and accounts
+
+**Owner**:
+A GitHub account morph.io knows about, either a User or an Organization. Named
+for owning scrapers, but used wherever an account is referenced, including
+collaborators, so an Owner does not necessarily own anything.
+_Avoid_: account, profile
+
+**User**:
+An Owner that is a person, and the only kind of Owner that can sign in.
+_Avoid_: member
+
+**Organization**:
+An Owner that is a GitHub organisation. Holds scrapers but never signs in.
+_Avoid_: org, team, group
+
+**Collaborator**:
+An Owner granted permissions on a Scraper's repository, mirrored from GitHub.
+_Avoid_: contributor, which is a different thing
+
+**Contributor**:
+A User who appears in the commit history of a Scraper's repository, taken from
+GitHub.
+_Avoid_: collaborator, author
+
+**Supporter**:
+A User or Organization paying to fund morph.io.
+_Avoid_: customer, subscriber, sponsor
+
+### Scrapers
+
+**Scraper**:
+A program in a GitHub repository that morph.io runs, together with everything
+morph.io keeps about it. Refers to the repository and the record
+interchangeably.
+_Avoid_: crawler, bot, job, spider
+
+**Language**:
+The one supported language a Scraper is written in: Ruby, Python, PHP, Perl or
+JavaScript. Determined by which scraper file the repository contains.
+_Avoid_: runtime, stack
+
+**Variable**:
+A named secret value morph.io passes into a Scraper's environment when it runs.
+Every name begins `MORPH_`.
+_Avoid_: secret value, env var, setting, config
+
+**Auto run**:
+The setting that has morph.io run a Scraper on a schedule rather than only when
+someone asks.
+_Avoid_: cron, scheduled, automatic
+
+**Broken scraper**:
+A Scraper whose most recent Run finished with an error. Drives what an Alert
+reports.
+_Avoid_: failing, failed, erroring
+
+### Running
+
+**Run**:
+One execution of scraper code in a container, together with its Log lines and
+the record of what it changed in the Data.
+_Avoid_: job, build, scrape, execution
+
+**Remote Run**:
+A Run of code uploaded from someone's own machine rather than fetched from a
+repository. Has no Scraper, and its Data is discarded when it finishes.
+_Avoid_: local run, CLI run, ad hoc run
+
+**Log line**:
+One line a Scraper wrote to stdout or stderr during a Run, streamed live to
+anyone watching the page.
+_Avoid_: output, console line, message
+
+**Slot**:
+One unit of capacity to hold a Run. The number of Slots caps how many Runs
+happen at once. Note that the setting controlling this is named
+`maximum_concurrent_scrapers` but counts Runs.
+_Avoid_: worker, queue place, concurrency limit
+
+### Data and delivery
+
+**Data**:
+The rows a Scraper has written, as people query and download them through the
+API.
+_Avoid_: dataset, results, output
+
+**Scraper database**:
+The SQLite file holding one Scraper's Data.
+_Avoid_: bare "database", which is ambiguous with morph.io's own MySQL
+database, the datastore, the dump
+
+**Webhook**:
+A URL morph.io posts to when a Scraper's Run finishes, so another system can
+react.
+_Avoid_: callback, hook, notification
+
+### Watching
+
+**Watch**:
+A standing subscription by a User to hear about a Scraper, or about every
+Scraper an Owner has.
+_Avoid_: alert, which is the email, subscription, follow
+
+**Watcher**:
+A User who holds a Watch.
+_Avoid_: subscriber, follower
+
+**Alert**:
+The email sent to a Watcher covering the Broken scrapers they watch, and the
+ones that have recovered.
+_Avoid_: notification, digest, warning
+
+### Traffic
+
+**Domain**:
+A site a Scraper made requests to, recorded so people can see what a Scraper
+scrapes and find scrapers by the sites they cover. Never morph.io's own domain,
+and unrelated to "domain" in the domain-modelling sense.
+_Avoid_: site, host, target
+
+**Connection log**:
+A record that a Run made a request to a Domain, captured from the proxy the
+Run's traffic passes through.
+_Avoid_: request log, access log

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ services-logs: ## View logs for services (use SERVICES=elasticsearch for specifi
 services-status: ## Check status of services
 	COMPOSE_PROJECT_NAME=morph-services docker compose -f docker_images/services.yaml ps
 
-rspec: ## Run all rspec tests (Optionally add DONT_RUN_SLOW_TESTS=1 or DONT_RUN_DOCKER_TESTS=1 or DONT_RUN_GITHUB_TESTS=1)
+rspec: ## Run all rspec tests (Optionally add DONT_RUN_DOCKER_TESTS=1 or DONT_RUN_GITHUB_TESTS=1)
 	RAILS_ENV=test bundle exec rspec
 
 test: quick-tests all-tests ## Run quick test then everything for a full coverage/index.html report

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,64 @@
+# Domain docs
+
+How the engineering skills should consume this repo's domain documentation when
+exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root. This exists. It is the glossary of
+  morph.io's domain terms, and it is opinionated about which words to avoid.
+- **`docs/adr/`**, reading the ADRs that touch the area you are about to work
+  in. This does not exist yet.
+
+If a file is not there, **proceed silently**. Do not flag its absence and do not
+suggest creating it upfront. The `/domain-modeling`
+skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`)
+creates them lazily when terms or decisions actually get resolved.
+
+`AGENTS.md` at the repo root is the standing guidance for this repository and
+is separate from all of this. Read it regardless.
+
+## Layout
+
+This is a **single-context** repo. One Rails application, one `Gemfile`, no
+workspaces:
+
+```
+/
+├── AGENTS.md          ← standing agent guidance (exists)
+├── CONTEXT.md         ← glossary of domain terms (exists)
+├── docs/
+│   ├── adr/           ← not created yet
+│   │   ├── 0001-some-decision.md
+│   │   └── 0002-another-decision.md
+│   └── agents/        ← this directory
+├── app/
+│   └── lib/morph/     ← the scraping, Docker and SQLite domain logic
+└── lib/
+```
+
+If morph.io ever splits into separately deployed packages, the multi-context
+form applies instead: a root `CONTEXT-MAP.md` pointing at one `CONTEXT.md` per
+context, with context-scoped ADRs beside each.
+
+Note the repo already has a `doc/` directory holding
+[`doc/UPGRADE_PATH.md`](../../doc/UPGRADE_PATH.md), which is the Rails
+convention and is not the same place. Agent-facing docs and ADRs go under
+`docs/`.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept, whether in an issue title, a refactor
+proposal, a hypothesis or a test name, use the term as defined in `CONTEXT.md`.
+Do not drift to synonyms the glossary explicitly avoids.
+
+If the concept you need is not in the glossary yet, that is a signal. Either
+you are inventing language the project does not use, in which case reconsider,
+or there is a real gap, which is worth noting for `/domain-modeling`.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than
+silently overriding it:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -22,13 +22,11 @@ CLI for all operations. Run it inside the clone and it infers the repo from
 
 - The issue and pull request templates are inherited from
   [`openaustralia/.github`](https://github.com/openaustralia/.github), not held
-  locally, so `gh issue create` will not offer a template to fill in. Follow
-  the org template's structure by hand.
-- Assign every pull request you open to yourself
-  (`gh pr create --assignee @me`), per the org `CONTRIBUTING.md`.
-- Disclose AI involvement as that guide asks: an
-  `Assisted-by: <agent-name>:<model-id>` trailer on each commit and a note in
-  the pull request description.
+  locally, so `gh issue create` will not offer a template to fill in. Fetch the
+  org template and follow its structure by hand.
+- How to open a pull request, who to assign it to, the DCO sign-off and AI
+  disclosure all come from the org standards. `AGENTS.md` links them at the top,
+  under "Org-wide standards". Read those rather than a copy here.
 
 ## Pull requests as a triage surface
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,90 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues on
+[`openaustralia/morph`](https://github.com/openaustralia/morph). Use the `gh`
+CLI for all operations. Run it inside the clone and it infers the repo from
+`git remote -v`.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a
+  heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments
+  by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+  with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply or remove labels**: `gh issue edit <number> --add-label "..."` or
+  `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## Repo specifics
+
+- The issue and pull request templates are inherited from
+  [`openaustralia/.github`](https://github.com/openaustralia/.github), not held
+  locally, so `gh issue create` will not offer a template to fill in. Follow
+  the org template's structure by hand.
+- Assign every pull request you open to yourself
+  (`gh pr create --assignee @me`), per the org `CONTRIBUTING.md`.
+- Disclose AI involvement as that guide asks: an
+  `Assisted-by: <agent-name>:<model-id>` trailer on each commit and a note in
+  the pull request description.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external
+PRs as feature requests. `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using
+the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments`, and `gh pr diff <number>`
+  for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments`
+  then keep only `authorAssociation` of `CONTRIBUTOR`,
+  `FIRST_TIME_CONTRIBUTOR` or `NONE`, dropping `OWNER`, `MEMBER` and
+  `COLLABORATOR`.
+- **Comment, label, close**: `gh pr comment`, `gh pr edit --add-label` or
+  `--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be
+either. Resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as
+tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes,
+  Decisions-so-far and Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api`
+  on the sub-issues endpoint). Where sub-issues are not enabled, add the child
+  to a task list in the map body and put `Part of #<map>` at the top of the
+  child body. Labels: `wayfinder:<type>`, one of `research`, `prototype`,
+  `grilling` or `task`. Once claimed, the ticket is assigned to the driving
+  dev.
+- **Blocking**: GitHub's **native issue dependencies**, which is the canonical,
+  UI-visible representation. Add an edge with
+  `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`,
+  where `<blocker-db-id>` is the blocker's numeric **database id**
+  (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, not the `#number` or the
+  `node_id`). GitHub reports `issue_dependencies_summary.blocked_by`, counting
+  open blockers only, which is the live gate. Where dependencies are not
+  available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the
+  child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`,
+  scoped to the map's sub-issues or task list), drop any with an open blocker
+  (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the
+  `Blocked by` line) or an assignee. First in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then
+  `gh issue close <n>`, then append a context pointer (gist plus link) to the
+  map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,28 @@
+# Triage labels
+
+The skills speak in terms of five canonical triage roles. This file maps those
+roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, for example "apply the AFK-ready triage label",
+use the corresponding label string from this table.
+
+All five already exist on `openaustralia/morph` with these exact names and
+descriptions, so apply them rather than creating new ones. Check with
+`gh label list --repo openaustralia/morph`.
+
+The repo carries a much larger label set alongside these, covering area
+(`Front end`, `Back end`, `API`, `search`, `buildpacks`, `admin interface`),
+kind (`bug`, `enhancement`, `New feature`, `documentation`, `security`,
+`devops`, `dependencies`) and workflow (`ready`, `in progress`, `backlog`,
+`High priority`). Those are orthogonal to triage state, so leave them alone
+when moving an issue through the triage state machine.
+
+Edit the right-hand column if the vocabulary ever changes.


### PR DESCRIPTION
## Description

Five commits, each doing one thing.

1. **Record agent conventions in `docs/agents`** (`703c6e8`) - the per-repo configuration the `mattpocock-skills` engineering skills expect: where issues live, the triage label vocabulary, and the domain doc layout, with a summary section in `AGENTS.md` pointing at them.
2. **Add `CONTEXT.md` glossary of morph.io terms** (`fe1dfe2`) - 24 terms, picking a canonical word per concept and listing the ones to avoid.
3. **Correct three claims that no longer hold** (`19e099b`) - an accuracy audit of `AGENTS.md` against the code.
4. **Reference OAF's org-wide standards instead of restating them** (`fa9ef28`) - removes the local copies of org rules and points at `openaustralia/.github` instead.
5. **Document how to run the app, and two missing pieces** (`e433d5e`) - plus a one-line `Makefile` fix.

**This is not quite documentation only.** Commit 5 changes one line of `Makefile`: the help text for the `rspec` target advertised `DONT_RUN_SLOW_TESTS=1`, which nothing in the repository reads, so passing it did nothing. The recipe itself is untouched and no behaviour changes, but it is not a markdown file, so it is called out here rather than buried.

## Motivation and Context

Resolves #1513.

`AGENTS.md` explained how to work in this repository but nothing recorded what morph.io's words mean, and several carry more than one meaning. `Alert` is the model while the association is `watch`, the person is a `watcher`, and the email `AlertMailer` sends is also an "alert". `collaborations.owner_id` holds collaborators, so an `Owner` need not own anything. `SiteSetting.maximum_concurrent_scrapers` caps concurrent runs, not scrapers. The per-scraper SQLite output is called both "data" and "database", while morph.io's own MySQL is also "the database". `CONTEXT.md` settles each of those.

### What the audit found

Two claims were left behind by the README alignment merged under #1506. `README.md` no longer has the "How to contribute" or "Branch naming" sections said to contradict the org guide, and no longer links to the missing `doc/docker_development_commands.md`.

The third was wrong rather than stale, and is the one worth a look. The mitmproxy connection-log path was described in the present tense, but `Morph::Runner` passes `disable_proxy: true` unconditionally, so a run never joins the proxy network. The container, the `connection_logs` endpoint and the code that displays and searches scraped domains all remain, on historical data only. Issue #1506 already records this half-live state as needing a product decision, so the wording now describes it and points there rather than implying it works. `CONTEXT.md` had inherited the same error in two entries.

### Why the org rules were removed rather than kept

`AGENTS.md` claimed to reference org guidance rather than copy it "because copies drift", and then held about 33 lines of copied org conventions, with nothing saying which version wins on a conflict. Rather than explain the exception, the copies are gone and there is now one "Org-wide standards" section pointing at the org `AGENTS.md`, `CONTRIBUTING.md` and the inherited templates, naming the topics each covers and stating that the org files win. The cost is that branch naming, the trailer format and the writing conventions now need a fetch. Recommendations for the org repository itself are being taken up separately.

### Not fixed here

Four contradictions between the code and its own comments are recorded but deliberately untouched. Two are wrong comments: `app/models/run.rb:49` says "A run of a scraper" when the association is optional, and `app/models/collaboration.rb:4` describes `Contribution` and has a typo. The other two, renaming the `Alert` model and `maximum_concurrent_scrapers`, need migrations and admin changes, so they belong in their own issues.

One ADR is worth writing, for scraper output living in a per-scraper SQLite file rather than in MySQL. It is not here because the reasoning is historical and should be recorded by someone who knows it, not inferred.

## How Has This Been Tested?

No Ruby, HAML, config or schema changed, so `rubocop`, `haml-lint` and the coverage thresholds are unaffected. There is no markdown linter in `.github/workflows`. The `Makefile` change was verified by running `make help` and confirming the target still renders with the flag gone.

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Left unchecked honestly: no test suite was run locally, and the four checks were still pending at the time of writing. They need confirming before this comes out of draft.

What was verified instead, claim by claim against the repository rather than assumed: the coverage thresholds and the conditions selecting them, all four test skip variables, both the Excon and WebMock workarounds, every `make` target named here, all the gem pins and their stated reasons, the Sorbet and annotaterb configuration, `db/scrapers` being gitignored and a Capistrano linked dir, the `:nocov:` markers matching `TESTING.md`, `app:promote_to_admin` existing, that `DONT_RUN_SLOW_TESTS` appeared nowhere else in the tree, that `make help` lists 24 targets, and that the fetch URL in the new section returns HTTP 200.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## AI assistance

Written with AI assistance (Claude Code:claude-opus-5). All five commits carry an `Assisted-by: Claude Code:claude-opus-5` trailer alongside the DCO sign-off, and all five are SSH signed.

The sign-off was added by the agent at my explicit instruction. The org guide is clear that the certification is a human's to make, so the content still needs my review before this leaves draft.
