### PR TITLE
Record upgrade path decisions, ADRs and glossary terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,12 @@ The one supported language a Scraper is written in: Ruby, Python, PHP, Perl or
 JavaScript. Determined by which scraper file the repository contains.
 _Avoid_: runtime, stack
 
+**Platform**:
+The base system image a Scraper's container is built on: cedar-14, heroku-18
+or heroku-24. A Scraper can pin one; otherwise it gets the default.
+_Avoid_: stack, which is Heroku's word for the same thing, base image,
+buildstep image
+
 **Variable**:
 A named secret value morph.io passes into a Scraper's environment when it runs.
 Every name begins `MORPH_`.
@@ -134,3 +140,11 @@ _Avoid_: site, host, target
 A record that a Run made a request to a Domain. Historical only, since the proxy
 that captured these is switched off.
 _Avoid_: request log, access log
+
+### Environments
+
+**Rehearsal server**:
+The server built ahead of the production migration to rehearse provisioning,
+the data move and cutover before anything depends on it. Becomes the staging
+environment once it exists; morph.io has none until then.
+_Avoid_: staging box, new server, dev.morph.io, which no longer exists

--- a/doc/UPGRADE_PATH.md
+++ b/doc/UPGRADE_PATH.md
@@ -1,7 +1,7 @@
 # Morph.io Comprehensive Upgrade Path
 
-Status: Proposed
-Last updated: 17 August 2026
+Status: Accepted
+Last updated: 20 August 2026
 
 This document is the single plan of record for bringing morph.io onto supported
 versions of its operating system, database, application stack and scraper
@@ -11,6 +11,9 @@ the work already merged, the work in flight, and the open issues across
 [openaustralia/morph](https://github.com/openaustralia/morph),
 [openaustralia/buildstep](https://github.com/openaustralia/buildstep) and
 [openaustralia/infrastructure](https://github.com/openaustralia/infrastructure).
+The hard-to-reverse decisions underpinning it are recorded as ADRs in
+[`docs/adr/`](../docs/adr/); the 20 August 2026 revision resolved the
+previously deferred decisions marked in §7.
 
 ## 1. Executive summary
 
@@ -35,7 +38,12 @@ Rails 7.2's security support ended 09 August 2026 and Rails 8.0's ends
 07 November 2026, so both are stepping stones only; **Rails 8.1 + Ruby 3.4 +
 Ubuntu 24.04 is the resting point.**
 
-Two hard constraints dictate the sequencing:
+The clock is the old server's accumulated risk, not an external deadline:
+**cutover (Phase 5) targets mid-November 2026**, three months from this
+revision, with a week-8 go/no-go checkpoint (§5). If the checkpoint fails,
+the date moves; the scope does not.
+
+Three hard constraints dictate the sequencing:
 
 1. **The current production server cannot go past Ruby 3.0.7.** rvm 1.29.3 on
    the box cannot update itself or install newer rubies. Rails hops up to 7.1
@@ -49,38 +57,54 @@ Two hard constraints dictate the sequencing:
    [buildstep#5](https://github.com/openaustralia/buildstep/pull/5) and
    [buildstep#7](https://github.com/openaustralia/buildstep/pull/7) are
    interim measures at best.
+3. **The new server cannot go below Ruby 3.1.** Ruby 3.0 and older do not
+   build against OpenSSL 3, which is all Ubuntu 24.04 ships. The new server
+   therefore runs Ruby 3.4 from day one, the Ruby 3.0.7 → 3.4 hop happens
+   *before* cutover (verified on the rehearsal server, Phase 4d), and no
+   application state ever needs to run on both servers: rollback during
+   cutover is a DNS flip back to the untouched old server, not a redeploy
+   ([ADR 0005](../docs/adr/0005-ruby-3-4-only-on-the-new-server.md)).
 
 The new server is therefore the lynchpin. It will be provisioned from the
 **openaustralia/infrastructure repository** (Terraform + Ansible), not from
 `morph/provisioning`, closing
 [infrastructure#341](https://github.com/openaustralia/infrastructure/issues/341)
 and bringing morph in line with how PlanningAlerts, RightToKnow and
-TheyVoteForYou are managed. Once cutover is complete, `morph/provisioning`
+TheyVoteForYou are managed
+([ADR 0002](../docs/adr/0002-provision-the-new-server-from-the-infrastructure-repository.md)).
+The new server stays on **Linode** (agreed with OAF ops, 20 August 2026):
+outbound IP reputation matters for a scraping workload, and AWS ranges are
+widely blocked by anti-bot services
+([ADR 0004](../docs/adr/0004-stay-on-linode-for-the-server-migration.md)).
+Once cutover is complete, `morph/provisioning`
 is removed and the morph repository retains application deployment
 (Capistrano) only.
 
 A decision has already been made that morph will **not** be replaced with a
 simpler AWS-native system (openaustralia/oaf-internal#308 — rejected). This
-plan upgrades morph in place.
+plan upgrades morph in place
+([ADR 0001](../docs/adr/0001-upgrade-morph-in-place.md)).
 
 ### Phase overview
 
 | Phase | What | Where it runs | Depends on |
 |---|---|---|---|
-| 0 | Baseline: CI green, security gem bumps, deprecation guard | current server | — (mostly done) |
-| 1 | Rails 6.0 → 6.1 | current server | 0 |
+| 0 | Baseline: CI green, security gem bumps, deprecation guard | current server | — (done) |
+| 1 | #1438 fix; Sentry gem; Rails 6.0 → 6.1 | current server | 0 |
 | 2 | Rails 6.1 → 7.0 + Ruby 3.0.7 | current server | 1 |
 | 3 | Rails 7.0 → 7.1 | current server | 2 |
-| 4 | New Ubuntu 24.04 server via infrastructure repo; disk cleanup | new server (staging first) | can start in parallel with 1–3 |
-| 5 | Data migration (MySQL 8.0 + utf8mb4), cutover, decommission old server | both | 3 + 4 |
-| 6 | Ruby 3.4; Rails 7.2 → 8.0 → 8.1; gem unblocks | new server | 5 |
+| 4 | New Ubuntu 24.04 rehearsal server via infrastructure repo; Ruby 3.4 app verification; disk cleanup | rehearsal server | can start in parallel with 1–3 |
+| 5 | Data migration (MySQL 8.0 + utf8mb4), cutover at Ruby 3.4, decommission old server | both | 3 + 4 |
+| 6 | Rails 7.2 → 8.0 → 8.1; gem unblocks | new server | 5 |
 | 7 | Buildstep heroku-24 working; old stacks deprecated; examples updated | new server | 5 (host Docker); can prepare earlier |
-| 8 | Observability (Sentry/OTel), backup monitoring, ancillary devops | new server | 5 |
+| 8 | Observability (OTel, Honeybadger retirement), backup monitoring, ancillary devops | new server | 5 |
 
-Phases 1–3 (application) and Phase 4 (infrastructure) are independent tracks
-that can proceed in parallel. Phase 7 preparation (buildstep image work,
-example scrapers, scraperwiki python3 branch) can also start before Phase 5,
-but final verification needs the new Docker host.
+Phases 1–3 (application) and Phase 4 (infrastructure) are independent tracks.
+In practice they are interleaved rather than truly parallel: Phase 1 goes to
+production first (momentum, and it de-risks every later hop), then Phase 4a
+porting starts while Phase 1 soaks. Phase 7 preparation (buildstep image
+work, example scrapers, scraperwiki python3 branch) can also start before
+Phase 5, but final verification needs the new Docker host.
 
 ## 2. Current state assessment
 
@@ -176,50 +200,80 @@ re-evaluated once the host is upgraded (§Phase 7).
   GHCR push fixed (buildstep#9); build-only CI for PRs (buildstep#6).
 - Database encoding groundwork: development encoding settled (#1493).
 - Rubocop config unified (#1503); deploy git tags (#1479).
+- Non-breaking security gem bumps merged (#1489, 18 August 2026).
+- AGENTS.md agent guidance merged (#1504, 18 August 2026).
+- Repository cleanup series for #1506 merged (PRs #1507, #1509, #1510,
+  #1511): dead app code and unused gems removed, support file drift and
+  README alignment fixed. Issue #1506 itself remains open.
 
 ### 2.5 In flight / stale
 
-- **Open PR [#1489](https://github.com/openaustralia/morph/pull/1489)** —
-  non-breaking security gem bumps (bundle-audit cleanup). Merge as part of
-  Phase 0. Remaining CVEs needing Ruby/Rails upgrades are tracked in
-  oaf-internal#316.
-- **Open PR [#1504](https://github.com/openaustralia/morph/pull/1504)** —
-  AGENTS.md documentation; independent of this plan.
 - **Stale upgrade branches** (PRs closed, branches kept): `chore/rails_61`
   (PR #1423, 116 commits behind main), `chore/rails_70_and_ruby_30`
   (PR #1424, 241 behind), `chore/rails_71` (PR #1425, 241 behind). These
-  contain substantial completed work and should be **rebased/mined, not
-  discarded**, in Phases 1–3.
+  contain substantial completed work and should be **mined, not rebased**
+  (see Phase 1 for why); delete each branch once its phase has mined it.
 - **Open buildstep PRs #5 and #7** — hold until Phase 7 decision.
+- Remaining CVEs needing Ruby/Rails upgrades are tracked in
+  oaf-internal#316.
 
 ## 3. Phased upgrade path
 
-### Phase 0 — Baseline (mostly complete)
+### Phase 0 — Baseline (complete)
 
 Goal: a trustworthy base to upgrade from.
 
-1. Merge PR #1489 (security gem bumps). Regenerate Sorbet RBIs.
+1. ~~Merge PR #1489 (security gem bumps). Regenerate Sorbet RBIs.~~ Done,
+   18 August 2026.
 2. Confirm CI is green including Brakeman and bundle-audit; keep the
    deprecation-raise guard from #1498 active so each Rails hop surfaces its
    deprecations in the test run rather than in production.
 3. Triage remaining bundle-audit findings into "fixed by Phase N" notes
    (oaf-internal#316).
 
-Exit criteria: CI green on `main`; no bundle-audit findings other than those
-explicitly deferred to later phases.
+Exit criteria met as of 18 August 2026: CI and Brakeman green on `main`;
+no bundle-audit findings other than those explicitly deferred to later
+phases.
 
-### Phase 1 — Rails 6.0 → 6.1 (current server)
+### Phase 1 — Precursors, Sentry, Rails 6.0 → 6.1 (current server)
 
 Closes #1355's predecessor step; issue tracking: epic #1351.
 
-1. Rebase or re-apply `chore/rails_61` onto current `main` (it is 116
-   commits behind; expect conflicts in Gemfile.lock, specs and config).
-2. `rails app:update`, adopt 6.1 defaults (`config.load_defaults 6.1`)
-   incrementally via `new_framework_defaults_6_1.rb`.
-3. Unpin `psych` to `>= 5.2.4` equivalent line (Rails 6.1 carries the
-   Psych 4 fix).
-4. Regenerate RBIs; fix deprecations until the guard passes.
-5. Deploy to staging, soak, deploy to production (Capistrano, unchanged).
+Two small standalone PRs land before the Rails work:
+
+1. **#1438 (unsafe sign-out redirect):** a small security fix that should
+   not share a diff with a framework bump.
+2. **Sentry gems** (advances #1474, moved forward from Phase 8): add
+   sentry-ruby/sentry-rails alongside Honeybadger. Honeybadger's limits are
+   already exhausted, and with no staging environment (see below) Sentry is
+   the soak instrument for every hop that follows. OTel, monitoring scope
+   and Honeybadger removal stay in Phase 8.
+
+Then the Rails hop:
+
+3. **Mine `chore/rails_61`, do not rebase it.** Stripped of regenerable
+   noise (RBIs, schema.rb, lockfiles) the branch is roughly 15 substantive
+   changes, and a wholesale rebase would reintroduce Active Storage
+   migrations that #1497 deliberately removed. Mining list: the Gemfile
+   bump, `add_template_helper` → `helper` in `AlertMailer`, the
+   `errors.keys` replacement in `Domain`, and the spec adjustments. Skip
+   its spring workaround (`main` is on spring 4, which should have the
+   fix — verify) and its Active Storage migrations. Delete the branch once
+   mined.
+4. Run `rails app:update` fresh, then adopt the 6.1 defaults in a single
+   PR with one commit per flag in `new_framework_defaults_6_1.rb`, ending
+   with `config.load_defaults 6.1`. The suite plus the deprecation guard
+   vets each flag; per-flag commits keep bisectability. The only flag
+   needing real thought is `cookies_same_site_protection = :lax` — the
+   GitHub OAuth callback is a top-level redirect so Lax is fine, but verify
+   sign-in explicitly after deploy.
+5. Unpin `psych` (Rails 6.1 carries the Psych 4 fix).
+6. Regenerate RBIs; fix deprecations until the guard passes.
+7. Deploy to production in a low-usage window. **There is no staging
+   environment** (dev.morph.io has no DNS record), so Phases 1–3 deploy
+   straight to production: `cap production deploy:rollback` is the
+   fallback, Sentry is the monitor, and each hop soaks about a week before
+   the next.
 
 ### Phase 2 — Rails 6.1 → 7.0 + Ruby 3.0.7 (current server)
 
@@ -237,20 +291,29 @@ Issues: [#1355](https://github.com/openaustralia/morph/issues/1355),
    continues to work (do not adopt the new asset pipeline defaults).
 4. Unpin `annotaterb`; bump `faraday`/`nokogiri` floors now allowed by
    Ruby 3.0.
-5. Deprecation guard clean; staging then production.
+5. Deprecation guard clean; production deploy in a low-usage window,
+   rollback point kept, one week soak on Sentry.
 
 ### Phase 3 — Rails 7.0 → 7.1 (current server)
 
 Issue: [#1358](https://github.com/openaustralia/morph/issues/1358).
 
-1. Rebase/mine `chore/rails_71`; `rails app:update`; adopt 7.1 defaults.
-2. Stay on Ruby 3.0.7 so this hop remains deployable to the **current**
-   production server as a safety resting point during the server migration.
-3. Deprecation guard clean; staging then production.
+1. Mine `chore/rails_71` (as in Phase 1: mine, do not rebase; delete the
+   branch after); `rails app:update`; adopt 7.1 defaults.
+2. Stay on Ruby 3.0.7: this is the last application state that deploys to
+   the **current** production server, and Ruby 3.0 is also the ceiling that
+   server can run.
+3. Deprecation guard clean; production deploy in a low-usage window,
+   rollback point kept, one week soak on Sentry.
 
-This is the last application state that must run on both the old and new
-servers (Rails 7.1 supports Ruby 3.0 through 3.4), which is exactly what
-makes the Phase 5 cutover low-risk for the app tier.
+Rails 7.1 supports Ruby 3.0 through 3.4, which makes it the bridge for the
+server migration — but not because the same state must run on both servers.
+It never does: the old server tops out at Ruby 3.0.7 and the new server
+starts at Ruby 3.4
+([ADR 0005](../docs/adr/0005-ruby-3-4-only-on-the-new-server.md)), and
+rollback during cutover is a DNS flip to the untouched old server, not a
+redeploy. The bridge is the *codebase*: one Rails version that runs on both
+Rubies, so the Ruby 3.4 change is the only app-tier difference at cutover.
 
 ### Phase 4 — New Ubuntu 24.04 server, provisioned from openaustralia/infrastructure
 
@@ -279,10 +342,15 @@ morph is the last OAF service provisioned from its own repo. Port
   the 24.04 archive (#1361: verify the distro version suffices before
   reaching for 7.2 from redis.io), Node.js LTS, Python 3 only (drop the
   python2 Ansible bootstrap), `/srv/www` layout consistently (#1382).
-- Ruby: replace rvm. Follow the infrastructure repo's established pattern
-  (`remove_rvm` role exists; pick mise or ruby-build consistent with what
-  the other OAF apps converge on). Update morph's `config/deploy.rb` to drop
-  `capistrano-rvm` accordingly.
+- Ruby: **keep rvm**, installed current via the infrastructure repo's
+  existing external `rvm.ruby` role, exactly as `theyvoteforyou` (Ruby
+  3.4.4) and `planningalerts` (Ruby 3.3.4) already run it. The fleet has
+  not converged on a replacement: `openaustralia` uses rbenv, and mise
+  support is half-built (its install role is commented out in `site.yml`
+  and a `remove_mise` role exists to purge it). morph's pain was a frozen
+  2017 rvm on Xenial, not rvm itself. `capistrano-rvm` stays; install
+  Ruby 3.4 only
+  ([ADR 0005](../docs/adr/0005-ruby-3-4-only-on-the-new-server.md)).
 - Secrets move into the shared infrastructure Ansible Vault (morph's
   `ansible.cfg` already uses the same vault password file).
 - Align with infrastructure repo initiatives while porting: Ansible version
@@ -290,10 +358,15 @@ morph is the last OAF service provisioned from its own repo. Port
   (infrastructure#580).
 
 **4b. Terraform the new machine** in `terraform/morph/` (the current Linode
-instance and Cloudflare DNS are already there). Open decision to record and
-resolve with OAF ops: stay on Linode vs move to AWS EC2 like the rest of the
-fleet (§7). Size the new machine *after* 4c — the goal in #1459 is to halve
-or quarter the current 32 GB/640 GB instance.
+instance and Cloudflare DNS are already there). **Hosting is decided**
+(20 August 2026, agreed with OAF ops): the new server stays on **Linode**.
+The deciding factor is outbound IP reputation for a scraping workload — AWS
+ranges are widely blocked by anti-bot services, and moving could silently
+degrade hundreds of scrapers in ways no rehearsal would reveal
+([ADR 0004](../docs/adr/0004-stay-on-linode-for-the-server-migration.md)).
+This also makes the RDS question (#1375) moot. Size the new machine *after*
+4c — the goal in #1459 is to halve or quarter the current 32 GB/640 GB
+instance.
 
 **4c. Disk cleanup on the current server (before migration, #1459):**
 trim `log_lines` aggressively and add the cron task (#1403), prune Docker
@@ -301,11 +374,24 @@ trim `log_lines` aggressively and add the cron task (#1403), prune Docker
 auto-run scrapers (#1380) for archival/removal with owner notification.
 Less data means a cheaper server and a much shorter cutover window.
 
-**4d. Build staging first** (#1352): provision a staging box with the new
-playbooks, deploy the Phase 3 app (Rails 7.1/Ruby 3.0.7) to it, and run the
-full test/verification suite there, including buildstep heroku-24 smoke
-tests (this is where #1473 is expected to disappear thanks to the new
-Docker Engine).
+**4d. Build the rehearsal server first** (#1352): provision a box with the
+new playbooks whose job is rehearsing everything before production depends
+on it — provisioning, the Ruby 3.4 app, data migration and cutover. From
+here on it is the staging environment this project otherwise lacks.
+
+- Deploy the Phase 3 app (Rails 7.1) to it at **Ruby 3.4**: this is where
+  the Ruby 3.0.7 → 3.4 hop (#1359) happens and is verified — keyword-arg
+  separation was already done in Phase 2, so expect mostly RBI churn,
+  stdlib gem extractions and Ruby 3.x strictness fixes. Update
+  `.ruby-version`, `Gemfile`, `config/deploy.rb`, CI and the development
+  `Dockerfile`; regenerate all Sorbet RBIs. Note that landing
+  the Ruby 3.4 change on `main` ends deployability to the old server (its
+  ceiling is 3.0.7), so merge it only once the rehearsal server has
+  validated it, shortly before cutover; until then it lives on a branch
+  deployed to the rehearsal server only.
+- Run the full test/verification suite there, including buildstep heroku-24
+  smoke tests (this is where #1473 is expected to disappear thanks to the
+  new Docker Engine).
 
 **4e. Decommission plan for morph-repo provisioning:** once production
 cutover (Phase 5) completes, remove `provisioning/`, `Vagrantfile`,
@@ -327,19 +413,22 @@ infrastructure [#266](https://github.com/openaustralia/infrastructure/issues/266
    5.7 → 8.0 dump/restore, following the approach in #1453 (new database
    with correct defaults, migrate data in, swap names). Set explicit
    `charset`/`collation` in the provisioned `database.yml` (#1494) so
-   schema.rb is identical between production and development ever after.
+   schema.rb is identical between production and development ever after
+   ([ADR 0003](../docs/adr/0003-mysql-8-and-utf8mb4-once-during-the-move.md)).
 2. Verify against MySQL 8.0 in CI/dev first: bump
    `docker_images/services.yaml` (mysql 8.0, redis 7.x) so the local stack
    matches the new server; run the suite; fix any 8.0 issues (sql_mode,
    `GROUP BY`, reserved words e.g. `groups`, auth plugin for `mysql2`).
-3. **Cutover runbook** (rehearse fully on staging):
+3. **Cutover runbook** (rehearse fully on the rehearsal server):
    - Pre-sync bulk data (scraper `data.sqlite` files, git repos, Docker
      images that survive cleanup) with rsync; iterate until delta is small.
    - Maintenance page on; stop queues (Sidekiq quiet → drain); final
      `mysqldump --single-transaction` → load into 8.0 with utf8mb4; final
      rsync delta; reindex Elasticsearch (searchkick reindex) on the new box.
-   - Deploy app via Capistrano to the new server; run smoke checks
-     (§6); flip DNS (Cloudflare, already in Terraform); watch error rates.
+   - Deploy app via Capistrano to the new server at Ruby 3.4 + Rails 7.1
+     (the Ruby hop was validated on the rehearsal server, Phase 4d); run
+     smoke checks (§6); flip DNS (Cloudflare, already in Terraform); watch
+     error rates in Sentry.
    - Rollback: DNS back to the old server, which is left untouched (read-only
      data divergence is the accepted cost within the cutover window; keep
      the window short and schedule in low-usage hours).
@@ -350,15 +439,16 @@ infrastructure [#266](https://github.com/openaustralia/infrastructure/issues/266
    confirm the long-broken SQL backup to S3 is verified working end-to-end
    (#1392) on the new machine.
 
-### Phase 6 — Ruby 3.4 and Rails 7.2 → 8.0 → 8.1 (new server)
+### Phase 6 — Rails 7.2 → 8.0 → 8.1 (new server)
 
-Issues: [#1359](https://github.com/openaustralia/morph/issues/1359),
+Issues: [#1359](https://github.com/openaustralia/morph/issues/1359) (done
+in Phase 4d/5),
 [#1360](https://github.com/openaustralia/morph/issues/1360) (retarget to
 8.1 per revised epic), epic #1351.
 
-1. **Ruby 3.0.7 → 3.4.x** (#1359): now possible on the new server. Update
-   `.ruby-version`, CI matrix, dev `Dockerfile`, Capistrano config.
-   Regenerate all Sorbet RBIs; expect fixes for Ruby 3.x strictness. Ruby
+1. **Ruby 3.0.7 → 3.4.x** (#1359): already done — it moved to Phase 4d/5
+   because Ruby 3.0 cannot run on the new server at all
+   ([ADR 0005](../docs/adr/0005-ruby-3-4-only-on-the-new-server.md)). Ruby
    4.0 exists but no Rails release is tested against it — stay on 3.4.
 2. **Rails 7.1 → 7.2.3.x** (brief hop; support already ended):
    `app:update`, defaults, deprecation-clean. Do not linger.
@@ -385,8 +475,9 @@ Issues: [#1359](https://github.com/openaustralia/morph/issues/1359),
      retirement in the same pass).
    - `elasticsearch`/`searchkick`: keep 7.17 client against ES 7.17; ES 8.x
      is a deferred decision (§7).
-6. After each hop: RBI regen, deprecation-guard-clean test run, staging
-   soak, production deploy. The Rails guide's advice (good coverage before
+6. After each hop: RBI regen, deprecation-guard-clean test run, soak on
+   the rehearsal server (the staging environment from Phase 4d onward),
+   production deploy. The Rails guide's advice (good coverage before
    8.x) is satisfied by the coverage work in #1437/#1436 — extend where
    gaps are found rather than blocking on a coverage number.
 
@@ -408,7 +499,7 @@ Issues: [#1476](https://github.com/openaustralia/morph/issues/1476),
 [#1336](https://github.com/openaustralia/morph/issues/1336),
 [#1337](https://github.com/openaustralia/morph/issues/1337).
 
-1. **Re-test heroku-24 on the new Docker host** (staging box from 4d). The
+1. **Re-test heroku-24 on the new Docker host** (rehearsal server from 4d). The
    clone3/seccomp failure class (#1473) should be resolved by the current
    Docker Engine. Then re-evaluate the open workaround PRs: buildstep#7
    (clone3-workaround) and buildstep#5 (sequential DNS) — merge only if a
@@ -433,7 +524,7 @@ Issues: [#1476](https://github.com/openaustralia/morph/issues/1476),
    scraperwiki install (#1205).
 5. **Example scrapers and language support decision** (#1443–#1448): update
    Ruby and Python examples to heroku-24 with current runtimes and verify
-   they run end-to-end on staging; then decide per #1476 whether PHP,
+   they run end-to-end on the rehearsal server; then decide per #1476 whether PHP,
    Node.js and Perl are worth fixing (63/18/5 daily scrapers respectively)
    or get deprecation notices and removal from the supported-languages
    documentation.
@@ -457,18 +548,18 @@ Issues: [#1474](https://github.com/openaustralia/morph/issues/1474),
 [#1403](https://github.com/openaustralia/morph/issues/1403);
 infrastructure [#363](https://github.com/openaustralia/infrastructure/issues/363).
 
-1. **Sentry** (#1474): add sentry-ruby/sentry-rails alongside Honeybadger,
-   run both during the Phase 5–6 window (upgrade phases are exactly when
-   error tracking matters most), then remove the `honeybadger` gem. OTel
-   configuration provisioned via the infrastructure repo roles or Rails
-   credentials (#1480). Decide separately on cron and APM monitoring scope
-   per the discussion on #1474.
+1. **Sentry** (#1474): the sentry-ruby/sentry-rails gems have been running
+   alongside Honeybadger since Phase 1 (upgrade phases are exactly when
+   error tracking matters most). Here: OTel configuration provisioned via
+   the infrastructure repo roles or Rails credentials (#1480), decide cron
+   and APM monitoring scope per the discussion on #1474, then remove the
+   `honeybadger` gem.
 2. **Drop the NewRelic infrastructure agent** from provisioning — it has
    never installed cleanly (#1210) and is superseded by the Sentry/OTel and
    CloudWatch patterns in the infrastructure repo.
 3. **Backups verified and monitored**: S3 SQL backup working (#1392),
    completion pings to Slack (infrastructure#266), restore drill documented
-   and performed once on staging.
+   and performed once on the rehearsal server.
 4. **Recurring DB hygiene** as cron (#1403): `log_lines` trim, sqlite
    vacuum after runs (#1215), docker prune policy that doesn't bust caches
    (#1124).
@@ -480,13 +571,14 @@ infrastructure [#363](https://github.com/openaustralia/infrastructure/issues/363
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
 | Stale rails_6x/7x branches conflict heavily with 8 months of main | High | Medium | Mine them for decisions (cookie serializer, app:update choices) rather than rebasing wholesale; redo mechanical parts |
-| utf8mb4 conversion corrupts or truncates data (index length limits, latin1-stored-as-utf8 mojibake) | Medium | High | Dump/restore into a fresh DB rather than in-place ALTER; verify row counts + checksums per table; spot-check known-emoji rows; rehearse on staging with a production dump |
-| MySQL 8.0 behaviour changes break queries (sql_mode, reserved words, auth plugin) | Medium | Medium | Run full suite + staging soak against 8.0 (Phase 5 step 2) before cutover |
-| heroku-24 still broken for some failure mode after Docker upgrade | Medium | High for scraper users | Staging smoke tests per language before any comms; keep heroku-18 image runnable (even if unbuildable) until heroku-24 verified; buildstep PRs #5/#7 held as fallback |
+| utf8mb4 conversion corrupts or truncates data (index length limits, latin1-stored-as-utf8 mojibake) | Medium | High | Dump/restore into a fresh DB rather than in-place ALTER; verify row counts + checksums per table; spot-check known-emoji rows; rehearse on the rehearsal server with a production dump |
+| MySQL 8.0 behaviour changes break queries (sql_mode, reserved words, auth plugin) | Medium | Medium | Run full suite + rehearsal-server soak against 8.0 (Phase 5 step 2) before cutover |
+| heroku-24 still broken for some failure mode after Docker upgrade | Medium | High for scraper users | Rehearsal-server smoke tests per language before any comms; keep heroku-18 image runnable (even if unbuildable) until heroku-24 verified; buildstep PRs #5/#7 held as fallback |
 | Cutover window data divergence (scrapers writing during migration) | Medium | Medium | Quiet queues + maintenance page; pre-sync so final delta is minutes; schedule low-usage window |
 | ActiveAdmin / Devise / omniauth lag behind Rails 8.x | Medium | Medium | Check compatibility matrix before each hop; these gems historically follow within a minor version — pin and wait rather than fork |
 | Sorbet friction on every hop (RBI churn, runtime checks) | High | Low | `tapioca gem` regeneration is a scripted step in each phase's checklist; treat RBI-only diffs as mechanical |
-| Losing rvm removes the only tested deploy path | Low | High | Phase 4d staging box proves the new ruby manager + Capistrano flow before production cutover |
+| Rails hops deployed to production without a staging soak (no staging environment exists) | Medium | Medium | Small verified hops; deprecation guard; low-usage deploy windows; `cap production deploy:rollback`; Sentry (installed Phase 1) watched for a week per hop |
+| Ruby 3.4 jump at cutover widens the app-tier delta | Medium | Medium | Rails 7.1 codebase is the bridge (supports Ruby 3.0–3.4); the Ruby hop is validated on the rehearsal server before `main` takes it; rollback stays a DNS flip |
 | Scraper-owner backlash at platform deprecation | Medium | Medium | Deprecation window with banner + email, migration guide, and #1476's data on how few scrapers use PHP/Node/Perl |
 | Key-person risk (upgrade knowledge concentrated in one contributor) | Medium | High | This document; PRs kept small and phase-scoped; decisions recorded in §7 |
 
@@ -500,36 +592,45 @@ Every phase must pass before the next begins:
 2. Zero Rails deprecation warnings (enforced by the #1498 guard).
 3. `bundle-audit` / Brakeman clean or explicitly waived with a phase noted.
 4. Sorbet: `srb tc` clean after RBI regeneration.
-5. Staging soak (dev.morph.io or the 4d staging box): sign-in via GitHub,
-   create scraper, run scraper on each supported platform, view live log
-   (Faye), download data, API query, webhook delivery, admin interface,
-   Sidekiq queues draining, Discourse up.
+5. Soak. For Phases 1–3 this is a **production soak**: deploy in a
+   low-usage window, keep the Capistrano rollback point, watch Sentry for
+   about a week (no staging environment exists — dev.morph.io has no DNS
+   record). From Phase 4d the **rehearsal server** takes this role, and the
+   checklist is: sign-in via GitHub, create scraper, run scraper on each
+   supported platform, view live log (Faye), download data, API query,
+   webhook delivery, admin interface, Sidekiq queues draining, Discourse
+   up.
 6. For server/DB phases additionally: backup + restore drill, error-tracker
    quiet for 48h post-deploy, per-table row-count/checksum comparison after
    data migration.
 7. For buildstep: the Ruby and Python example scrapers run end-to-end on
-   heroku-24 on staging *and* production before any deprecation comms go
-   out.
+   heroku-24 on the rehearsal server *and* production before any
+   deprecation comms go out.
+8. **Week-8 go/no-go (target: mid-October 2026):** if the rehearsal server
+   has not completed a full cutover rehearsal by eight weeks into the
+   three-month window, the cutover date moves. Scope does not — every §7
+   deferral has already stripped the plan to essentials, and descoping
+   would only create a second migration later.
 
 ## 6. Issue and PR mapping
 
 | Phase | Closes / advances |
 |---|---|
 | 0 | morph PR #1489; parts of oaf-internal#316 |
-| 1 | epic #1351 (6.1 step); supersedes PR #1423 branch |
+| 1 | epic #1351 (6.1 step); #1438; advances #1474 (Sentry gems); supersedes PR #1423 branch |
 | 2 | #1355, #1356; supersedes PR #1424 branch |
 | 3 | #1358; supersedes PR #1425 branch |
-| 4 | #1374, #1362, #1352, #1361, #1382, #1459 (with 5), #1210; infrastructure#341, advances infrastructure#574/#580; parts of #1340 |
+| 4 | #1374, #1362, #1352, #1361, #1382, #1459 (with 5), #1359 (with 5), #1210; infrastructure#341, advances infrastructure#574/#580; parts of #1340 |
 | 5 | #1453, #1494, #1357, #1392 (verify), #1403; infrastructure#266 |
-| 6 | #1359, #1360 (retargeted to 8.1), remainder of epic #1351; sidekiq/omniauth/octokit/render_sync TODOs in Gemfile |
+| 6 | #1360 (retargeted to 8.1), remainder of epic #1351; sidekiq/omniauth/octokit/render_sync TODOs in Gemfile |
 | 7 | #1476, #1473, #1464, #1450, #1451, #1443, #1444, #1445, #1446, #1447, #1448, #1462, #1344, #1334, #1335, #1336, #1337, #1205, #1339, #1223; buildstep PRs #5, #7 (merge-or-close decision) |
 | 8 | #1474, #1480, #1210 (removal), #1392, #1403; infrastructure#363, #364 |
 
 Issues **not** covered by this plan (functional bugs/features — triage
 separately): the large backlog of enhancement/bug issues (e.g. #1461,
-#1457, #1454, #1465, #1469, #1438 and older). One exception worth bundling:
-**#1438 (unsafe sign-out redirect)** is a small security fix that should be
-picked up in Phase 0/1 rather than waiting.
+#1457, #1454, #1465, #1469 and older). One exception already bundled:
+**#1438 (unsafe sign-out redirect)** is a small security fix picked up as a
+standalone PR at the start of Phase 1 rather than waiting.
 
 ### Zenhub tracking
 
@@ -555,21 +656,25 @@ as issue types, parent/child relationships and blocking dependencies:
 
 ## 7. Deferred decisions
 
-Record the outcome of each of these in this document when made:
+Record the outcome of each of these in this document when made. Three were
+resolved in the 20 August 2026 revision and are marked **Decided**:
 
 | Decision | Options | When needed | Notes |
 |---|---|---|---|
-| Hosting for the new server | Stay Linode vs AWS EC2 (fleet-standard) | Phase 4b | Infrastructure repo tooling (inventory, CloudWatch, SSM, backups) is AWS-shaped; Linode keeps continuity. |
-| Managed database | Local MySQL vs RDS (#1375) | Phase 4b | Only meaningful if AWS is chosen. Spike issue exists; do not block the migration on it. |
+| Hosting for the new server | **Decided (20 Aug 2026, with OAF ops): stay on Linode** | Phase 4b | Outbound IP reputation for a scraping workload was the deciding factor; AWS ranges are widely blocked by anti-bot services ([ADR 0004](../docs/adr/0004-stay-on-linode-for-the-server-migration.md)). Revisit if fleet-tooling benefits ever outweigh continuity. |
+| Managed database | **Moot while hosting stays Linode** (#1375) | — | Was only meaningful if AWS had been chosen. |
 | Postgres (#1058) | Stay MySQL vs migrate | Not in this plan | Explicitly out of scope; utf8mb4 MySQL 8 is the target. Revisit after Rails 8.1. |
 | Search | ES 7.17 vs ES 8.x vs OpenSearch | After Phase 6 | searchkick 5 supports all three; 7.17 is safe through this plan. |
 | PHP / Node.js / Perl support | Fix on heroku-24 vs deprecate | Phase 7 step 5 | Usage data in #1476. |
-| Ruby version manager on servers | mise vs ruby-build/system | Phase 4a | Follow whatever the infrastructure repo standardises on for the other Rails apps. |
+| Ruby version manager on servers | **Decided (20 Aug 2026): keep rvm**, installed current via the infrastructure repo's `rvm.ruby` role | Phase 4a | Fleet majority (theyvoteforyou, planningalerts); no OAF convergence exists to follow — mise is half-built and only openaustralia uses rbenv. morph's pain was a frozen 2017 rvm on Xenial, not rvm itself. |
 | Live-updates stack | Keep Faye/render_sync vs Turbo Streams/ActionCable | Phase 6 step 5 | render_sync fork is unmaintained; scope carefully — it touches core UX. |
-| Cron/APM monitoring scope in Sentry | Errors only vs cron vs APM | Phase 8 | Depends on sponsored plan quotas (#1474 discussion). |
+| Cron/APM monitoring scope in Sentry | Errors only vs cron vs APM | Phase 8 | Depends on sponsored plan quotas (#1474 discussion). The Sentry gems themselves land in Phase 1. |
 
 ## 8. References
 
+- [Architecture decision records](../docs/adr/) — the hard-to-reverse
+  decisions behind this plan (upgrade in place, provisioning home, MySQL
+  8.0 + utf8mb4, Linode, Ruby 3.4-only new server)
 - [Epic #1351 — Update Morph Software versions](https://github.com/openaustralia/morph/issues/1351)
   (strategy, version research, support dates — revised 15 Aug 2026)
 - [Rails upgrade guide](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html)

--- a/docs/adr/0001-upgrade-morph-in-place.md
+++ b/docs/adr/0001-upgrade-morph-in-place.md
@@ -1,0 +1,11 @@
+# Upgrade morph in place rather than replace it
+
+Status: accepted
+
+Almost every layer of morph.io is past end of life, and the alternative of
+replacing it with a simpler AWS-native system was considered and rejected
+(openaustralia/oaf-internal#308). morph.io is a working product with active
+users, thousands of scrapers and years of accumulated data; a rewrite risks
+all of that to solve a versions problem. We upgrade the existing application
+in place, in small verified hops, per the plan in
+[`doc/UPGRADE_PATH.md`](../../doc/UPGRADE_PATH.md).

--- a/docs/adr/0002-provision-the-new-server-from-the-infrastructure-repository.md
+++ b/docs/adr/0002-provision-the-new-server-from-the-infrastructure-repository.md
@@ -1,0 +1,21 @@
+# Provision the new server from the infrastructure repository
+
+Status: accepted
+
+morph is the last OAF service provisioned from its own repository
+(`morph/provisioning`). The new Ubuntu 24.04 server is provisioned from
+[openaustralia/infrastructure](https://github.com/openaustralia/infrastructure)
+(Terraform + Ansible) instead, closing infrastructure#341: it reuses the
+shared roles (base-server, mysql, deploy-user, backups, certbot) and the
+shared Ansible Vault, and brings morph in line with how PlanningAlerts,
+RightToKnow and TheyVoteForYou are managed. Once cutover completes,
+`morph/provisioning`, the Vagrantfile and the Makefile ansible targets are
+removed from this repository, which then retains application deployment
+(Capistrano) and local docker-compose development only.
+
+## Consequences
+
+Infrastructure changes for morph happen in a different repository from the
+application, with its own review flow. The genuinely morph-specific roles
+(morph-app, docker-server, nginx-passenger, discourse, mitmproxy) are ported
+there rather than kept here.

--- a/docs/adr/0003-mysql-8-and-utf8mb4-once-during-the-move.md
+++ b/docs/adr/0003-mysql-8-and-utf8mb4-once-during-the-move.md
@@ -1,0 +1,24 @@
+# Convert to MySQL 8.0 and utf8mb4 once, during the server move
+
+Status: accepted
+
+Production MySQL 5.7 holds a mix of latin1 and utf8mb3 encodings: tables
+differ between production and a freshly migrated development database
+(#1494), and 4-byte UTF-8 such as emoji in scraper output causes production
+errors (#1453). Rather than an in-place `ALTER` on the old server or
+carrying the mess to the new one, the whole database is converted to
+`utf8mb4`/`utf8mb4_unicode_ci` exactly once, as part of the 5.7 to 8.0
+dump/restore during the server migration: a fresh database with correct
+defaults, data migrated in, names swapped. The provisioned `database.yml`
+sets explicit charset and collation so the schema never drifts again.
+
+## Considered options
+
+- In-place `ALTER TABLE` on the current server: risks index length limits
+  and mojibake on latin1-stored-as-utf8 rows, on a box with no rehearsal
+  environment.
+- Migrate encodings later, after cutover: carries the known emoji failures
+  onto the new server and means a second maintenance window.
+
+Verification is per-table row counts and checksums plus spot-checks of
+known-emoji rows, rehearsed against a production dump before cutover.

--- a/docs/adr/0004-stay-on-linode-for-the-server-migration.md
+++ b/docs/adr/0004-stay-on-linode-for-the-server-migration.md
@@ -1,0 +1,21 @@
+# Stay on Linode for the server migration
+
+Status: accepted
+
+Decided with OAF ops, 20 August 2026. The rest of the OAF fleet runs on AWS
+and the infrastructure repository's tooling (inventory, CloudWatch, SSM,
+backups) is AWS-shaped, so EC2 was the obvious default. The new morph server
+stays on Linode anyway, because morph's workload is scraping: outbound IP
+reputation matters, AWS address ranges are aggressively blocked by anti-bot
+services, and moving could silently degrade hundreds of scrapers in ways no
+rehearsal would reveal. Continuity and cheap egress for the bulk data move
+are secondary benefits.
+
+## Consequences
+
+- The managed-database question (RDS, #1375) is moot while hosting stays
+  Linode.
+- The AWS-shaped conveniences in the infrastructure repository are forgone
+  for morph; revisit this decision if those ever outweigh the
+  IP-reputation risk, with a plan for measuring scraper success rates
+  before and after any move.

--- a/docs/adr/0005-ruby-3-4-only-on-the-new-server.md
+++ b/docs/adr/0005-ruby-3-4-only-on-the-new-server.md
@@ -1,0 +1,30 @@
+# Ruby 3.4 only on the new server
+
+Status: accepted
+
+The upgrade plan originally kept Ruby 3.0.7 through cutover so that one
+application state could run on both the old and new servers. That premise
+hits a wall: Ruby 3.0 and older do not build against OpenSSL 3, which is
+all Ubuntu 24.04 ships. The new server therefore runs Ruby 3.4 only, the
+Ruby 3.0.7 to 3.4 hop happens before cutover and is validated on the
+rehearsal server, and Rails 7.1 (which supports Ruby 3.0 through 3.4) is
+the bridge codebase across the migration.
+
+The premise was also stronger than needed: rollback during the cutover
+window is a DNS flip back to the untouched old server, not a redeploy, so
+no moment requires one deployable state on both machines.
+
+## Considered options
+
+- Vendor OpenSSL 1.1.1 into rvm on the new server so Ruby 3.0.7 runs
+  there: rejected, because it puts an end-of-life crypto library (and an
+  end-of-life Ruby) on the box this migration exists to make supportable.
+
+## Consequences
+
+- Landing the Ruby 3.4 change on `main` ends deployability to the old
+  server, whose ceiling is Ruby 3.0.7. It merges only after the rehearsal
+  server has validated it, shortly before cutover; until then it lives on
+  a branch deployed to the rehearsal server only.
+- Phase 6 of the upgrade plan starts at the Rails 7.2 hop with Ruby
+  already done.


### PR DESCRIPTION
Records the outcome of a plan review of `doc/UPGRADE_PATH.md` held on 20 August 2026, stacked on #1514 because it builds on the glossary added there.

## What changed

**`doc/UPGRADE_PATH.md`** (status: Proposed → Accepted)

- Cutover targets mid-November 2026, three months out, with a week-8 go/no-go checkpoint in §5. If the checkpoint fails the date moves, not the scope.
- A third hard constraint added: Ruby 3.0 cannot build against OpenSSL 3, which is all Ubuntu 24.04 ships. The Ruby 3.0.7 → 3.4 hop therefore happens before cutover on the rehearsal server, and Phase 6 starts at the Rails 7.2 hop. The old "one state must run on both servers" rationale was never needed: rollback is a DNS flip.
- Phase 4a keeps rvm instead of replacing it. The fleet has not converged (theyvoteforyou and planningalerts run current rvm at Ruby 3.3/3.4, openaustralia runs rbenv, mise support is half-built); morph's pain was a frozen 2017 rvm on Xenial, not rvm itself.
- Hosting decided with OAF ops: stay on Linode. Outbound IP reputation for a scraping workload was the deciding factor. The RDS question is moot.
- No staging environment exists (dev.morph.io has no DNS record), so Phases 1–3 deploy per hop straight to production in low-usage windows with rollback points and about a week of soak each; the Phase 4d box is named the rehearsal server and becomes the staging environment from there on.
- Sentry gems move forward from Phase 8 to Phase 1 (Honeybadger's limits are already exhausted, and Sentry is the soak instrument for the hops). #1438 lands as a standalone security PR before the Rails work.
- Stale rails_61/70/71 branches are mined, not rebased: stripped of regenerable noise they are ~15 substantive changes each, and a rebase would reintroduce Active Storage migrations removed by #1497.
- §2 refreshed: #1489 and #1504 merged 18 August; the #1506 cleanup series merged as PRs #1507/#1509/#1510/#1511 (issue itself still open); Phase 0 exit criteria met.

**`docs/adr/`** (new)

Five ADRs recording the hard-to-reverse decisions: 0001 upgrade in place, 0002 provision from the infrastructure repository, 0003 MySQL 8.0 + utf8mb4 once during the move, 0004 stay on Linode, 0005 Ruby 3.4 only on the new server.

**`CONTEXT.md`**

Two glossary terms the plan needs used consistently: **Platform** (the buildstep base image, matching `PLATFORMS` in the code; avoid Heroku's "stack") and **Rehearsal server**.

## AI disclosure

This pull request was written with AI assistance (OpenCode with Claude, model anthropic.claude-fable-5), driven and reviewed by @benrfairless. The plan review it records was an interactive session; every decision in it was made by a human.

Advances 
* #1351.
