### PR TITLE
Only follow safe referers after sign out

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@
 class ApplicationController < ActionController::Base
   extend T::Sig
 
+  # Only redirect back to simple one- or two-segment paths like "/documentation"
+  # or "/some_user/some_scraper" after sign out
+  SAFE_SIGN_OUT_PATH_REGEXP = T.let(%r{\A(/[^/?#]+){1,2}\z}.freeze, Regexp)
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -30,9 +34,22 @@ class ApplicationController < ActionController::Base
     session[:previous_url] = request.fullpath unless request.fullpath =~ %r{/users}
   end
 
-  sig { params(_resource: T.untyped).returns(T.nilable(String)) }
+  # The referer is client supplied, so only follow it back to a simple path on
+  # our own host. Anything else is an open redirect (see issue #1438).
+  sig { params(_resource: T.untyped).returns(String) }
   def after_sign_out_path_for(_resource)
-    request.referer ? URI.parse(request.referer).path : root_path
+    referer = request.referer
+    return root_path if referer.blank?
+
+    uri = URI.parse(referer)
+    return root_path if uri.host != request.host || uri.query || uri.fragment
+
+    path = uri.path
+    return root_path if path.nil? || !path.match?(SAFE_SIGN_OUT_PATH_REGEXP)
+
+    path
+  rescue URI::InvalidURIError
+    root_path
   end
 
   # Overriding the default ability class name used because we've split them out. See

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -17,24 +17,72 @@ describe ApplicationController do
   end
 
   describe "#after_sign_out_path_for" do
+    def stub_referer(referer)
+      allow(controller).to receive(:request).and_return(
+        instance_double(ActionDispatch::Request, referer: referer, host: "morph.io")
+      )
+    end
+
+    def after_sign_out_path
+      controller.send(:after_sign_out_path_for, :any_scope)
+    end
+
     before do
       allow(controller).to receive(:root_path).and_return(root_path)
     end
 
-    # FIXME: This is not safe to do!
-    it "returns referer path" do
-      referer = "/some_user/some_scraper"
-      allow(controller).to receive(:request).and_return(instance_double(ActionDispatch::Request, referer: referer))
+    it "returns the referer path when the referer is on our own host" do
+      stub_referer("https://morph.io/some_user/some_scraper")
 
-      path = controller.send(:after_sign_out_path_for, :any_scope)
-      expect(path).to eq referer
+      expect(after_sign_out_path).to eq "/some_user/some_scraper"
     end
 
-    it "defaults to root path" do
-      allow(controller).to receive(:request).and_return(instance_double(ActionDispatch::Request, referer: nil))
+    it "defaults to root path when there is no referer" do
+      stub_referer(nil)
 
-      path = controller.send(:after_sign_out_path_for, :any_scope)
-      expect(path).to eq root_path
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "does not redirect to a referer on another host" do
+      stub_referer("https://evil.example.com/signed_out")
+
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "defaults to root path for a relative referer" do
+      stub_referer("/some_user/some_scraper")
+
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "does not produce a protocol-relative redirect from a doubled slash" do
+      stub_referer("https://morph.io//evil.example.com/signed_out")
+
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "does not redirect to a referer with a query string" do
+      stub_referer("https://morph.io/some_user/some_scraper?evil=1")
+
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "does not redirect to a referer with a fragment" do
+      stub_referer("https://morph.io/some_user/some_scraper#evil")
+
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "does not redirect to a deeply nested path" do
+      stub_referer("https://morph.io/a/b/c")
+
+      expect(after_sign_out_path).to eq root_path
+    end
+
+    it "defaults to root path when the referer is not a valid URI" do
+      stub_referer("https://morph.io/some path with spaces")
+
+      expect(after_sign_out_path).to eq root_path
     end
   end
 


### PR DESCRIPTION
Fixes #1438.

## What this does

`ApplicationController#after_sign_out_path_for` followed the client-supplied `request.referer` blindly, which is an open redirect: an attacker can bounce a user through morph.io's sign-out and back to a phishing page (see the reproduction steps in #1438). Returning only the parsed *path* did not close the hole either, because a referer like `https://morph.io//evil.example.com/x` yields the protocol-relative path `//evil.example.com/x`, which browsers treat as a full URL on the other host. A malformed referer also raised `URI::InvalidURIError` (a 500).

This implements the issue's option 2 (validated referer): only redirect back to the referer when it is on our own host, has no query or fragment, and is a simple one- or two-segment path like `/some_user/some_scraper`; everything else falls back to the root path.

One deliberate deviation from the sketch in the issue: the `TypeError` rescue is omitted, because the `blank?` guard means `URI.parse` only ever receives a non-empty string, which cannot raise `TypeError`.

One part of option 2 is deliberately not enforced: "a page that can be displayed without authentication". The path regex admits auth-required pages like `/settings`, matching the issue's own proposed code, which has the same property. The worst case there is a bounce to the sign-in redirect on our own host, not an open redirect, and maintaining a whitelist of unauthenticated routes in the controller did not seem worth that trade.

## Testing

TDD'd: the rewritten specs (cross-host referer, doubled slash, query string, fragment, deep path, relative referer, invalid URI) were run red against the old implementation first - six of them failed, confirming they detect the vulnerability - then green against the fix.

- Target spec: 12 examples, 0 failures
- Full CI-profile suite (`DONT_RUN_DOCKER_TESTS=1 RUN_SLOW_TESTS=1 DONT_RUN_GITHUB_TESTS=1`) in the Docker dev environment: 848 examples, 0 failures, 17 pending, coverage 81.39%
- RuboCop clean; `srb tc` unchanged against the pre-existing baseline

Note on coverage: the quick-tests SimpleCov threshold (77.08) fails in my container on `main` as well (76.67 baseline vs 76.72 with this change - coverage goes up, not down), so the hardcoded threshold has not been touched; CI's own profile is the gate that counts.

## AI disclosure

This change was written with the assistance of an AI coding agent (OpenCode running anthropic.claude-fable-5), driven and reviewed by @benrfairless.
